### PR TITLE
Allow to use custom instances of XMLInputFactory and XMLOutputFactory

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -47,7 +47,7 @@ public class AASXDeserializer {
     private static final String XML_TYPE = "http://www.admin-shell.io/aasx/relationships/aas-spec";
     private static final String AASX_ORIGIN = "/aasx/aasx-origin";
 
-    private XmlDeserializer deserializer = new XmlDeserializer();
+    private final XmlDeserializer deserializer;
 
     private Environment environment;
     private final OPCPackage aasxRoot;
@@ -61,6 +61,7 @@ public class AASXDeserializer {
      */
     public AASXDeserializer(InputStream inputStream) throws InvalidFormatException, IOException {
         aasxRoot = OPCPackage.open(inputStream);
+        this.deserializer = new XmlDeserializer();
     }
 
     /**

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -61,12 +61,13 @@ public class AASXSerializer {
 
     private static final String AASSUPPL_RELTYPE = "http://www.admin-shell.io/aasx/relationships/aas-suppl";
 
-    private Serializer xmlSerializer = new XmlSerializer();
+    private final Serializer xmlSerializer;
 
     /**
      * Default constructor
      */
     public AASXSerializer() {
+        this.xmlSerializer = new XmlSerializer();
     }
 
     /**

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlDeserializer.java
@@ -31,10 +31,12 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 
 public class XmlDeserializer implements Deserializer {
 
+    protected final XmlFactory xmlFactory;
     protected XmlMapper mapper;
     protected SimpleAbstractTypeResolver typeResolver;
 	@SuppressWarnings("rawtypes")
@@ -42,12 +44,18 @@ public class XmlDeserializer implements Deserializer {
             SubmodelElement.class, new SubmodelElementDeserializer());
 
     public XmlDeserializer() {
+        this(new XmlFactory());
+    }
+
+    public XmlDeserializer(XmlFactory xmlFactory) {
+        this.xmlFactory = xmlFactory;
         initTypeResolver();
         buildMapper();
     }
 
     protected void buildMapper() {
-        mapper = XmlMapper.builder().enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+        mapper = XmlMapper.builder(xmlFactory)
+                .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .serializationInclusion(JsonInclude.Include.NON_NULL)
                 .annotationIntrospector(new XmlDataformatAnnotationIntrospector())

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSerializer.java
@@ -36,11 +36,13 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 
 public class XmlSerializer implements Serializer {
+    protected final XmlFactory xmlFactory;
     protected XmlMapper mapper;
     protected Map<String, String> namespacePrefixes;
 
@@ -49,12 +51,17 @@ public class XmlSerializer implements Serializer {
     }
 
     public XmlSerializer(Map<String, String> namespacePrefixes) {
+        this(new XmlFactory(), namespacePrefixes);
+    }
+
+    public XmlSerializer(XmlFactory xmlFactory, Map<String, String> namespacePrefixes) {
+        this.xmlFactory = xmlFactory;
         this.namespacePrefixes = namespacePrefixes;
         buildMapper();
     }
 
     protected void buildMapper() {
-        mapper = XmlMapper.builder()
+        mapper = XmlMapper.builder(xmlFactory)
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
                 .serializationInclusion(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
This change allows to pass custom factories to the AASX and XML serializers and deserializers.

Fixes #53 