### PR TITLE
Add support for thumbnails in AASXSerializer / AASXDeserializer

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -39,6 +39,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.File;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 
 /**
  * The AASX package converter converts a aasx package into a list of aas, a list
@@ -148,6 +149,9 @@ public class AASXDeserializer {
         read();
 
         List<String> paths = new ArrayList<>();
+        for (AssetAdministrationShell aas : environment.getAssetAdministrationShells()) {
+            paths.add(aas.getAssetInformation().getDefaultThumbnail().getPath());
+        }
         for (Submodel sm : environment.getSubmodels()) {
             paths.addAll(parseElements(sm.getSubmodelElements()));
         }

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -151,8 +151,8 @@ public class AASXDeserializer {
 
         List<String> paths = new ArrayList<>();
         environment.getAssetAdministrationShells().stream().filter(aas -> aas.getAssetInformation() != null
-                        || aas.getAssetInformation().getDefaultThumbnail() != null
-                        || aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
+                        && aas.getAssetInformation().getDefaultThumbnail() != null
+                        && aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
                 .forEach(aas -> paths.add(aas.getAssetInformation().getDefaultThumbnail().getPath()));
         environment.getSubmodels().forEach(sm -> paths.addAll(parseElements(sm.getSubmodelElements())));
         return paths;

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -150,16 +150,11 @@ public class AASXDeserializer {
         read();
 
         List<String> paths = new ArrayList<>();
-        for (AssetAdministrationShell aas : environment.getAssetAdministrationShells()) {
-            AssetInformation information = aas.getAssetInformation();
-            if(information == null || information.getDefaultThumbnail() == null || information.getDefaultThumbnail().getPath() == null) {
-                continue;
-            }
-            paths.add(aas.getAssetInformation().getDefaultThumbnail().getPath());
-        }
-        for (Submodel sm : environment.getSubmodels()) {
-            paths.addAll(parseElements(sm.getSubmodelElements()));
-        }
+        environment.getAssetAdministrationShells().stream().filter(aas -> aas.getAssetInformation() != null
+                        || aas.getAssetInformation().getDefaultThumbnail() != null
+                        || aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
+                .forEach(aas -> paths.add(aas.getAssetInformation().getDefaultThumbnail().getPath()));
+        environment.getSubmodels().forEach(sm -> paths.addAll(parseElements(sm.getSubmodelElements())));
         return paths;
     }
 

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -40,6 +40,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
 
 /**
  * The AASX package converter converts a aasx package into a list of aas, a list

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -150,6 +150,10 @@ public class AASXDeserializer {
 
         List<String> paths = new ArrayList<>();
         for (AssetAdministrationShell aas : environment.getAssetAdministrationShells()) {
+            AssetInformation information = aas.getAssetInformation();
+            if(information == null || information.getDefaultThumbnail() == null || information.getDefaultThumbnail().getPath() == null) {
+                continue;
+            }
             paths.add(aas.getAssetInformation().getDefaultThumbnail().getPath());
         }
         for (Submodel sm : environment.getSubmodels()) {

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -42,6 +42,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
 
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.SerializationException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.internal.AASXUtils;

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -128,8 +128,8 @@ public class AASXSerializer {
     private void storeFilesInAASX(Environment environment, Collection<InMemoryFile> files, OPCPackage rootPackage,
                                   PackagePart xmlPart) {
         environment.getAssetAdministrationShells().stream().filter(aas -> aas.getAssetInformation() != null
-                || aas.getAssetInformation().getDefaultThumbnail() != null
-                || aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
+                && aas.getAssetInformation().getDefaultThumbnail() != null
+                && aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
                 .forEach(aas -> createParts(files,
                         AASXUtils.getPathFromURL(aas.getAssetInformation().getDefaultThumbnail().getPath()),
                         rootPackage, xmlPart, aas.getAssetInformation().getDefaultThumbnail().getContentType()));

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -127,6 +127,10 @@ public class AASXSerializer {
     private void storeFilesInAASX(Environment environment, Collection<InMemoryFile> files, OPCPackage rootPackage,
                                   PackagePart xmlPart) {
         for (AssetAdministrationShell aas : environment.getAssetAdministrationShells()) {
+            AssetInformation information = aas.getAssetInformation();
+            if(information == null || information.getDefaultThumbnail() == null || information.getDefaultThumbnail().getPath() == null) {
+                continue;
+            }
             String filePath = AASXUtils.getPathFromURL(aas.getAssetInformation().getDefaultThumbnail().getPath());
             try {
                 InMemoryFile content = findFileByPath(files, filePath);

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/AASXDeserializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/AASXDeserializerTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.deserialization;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -27,6 +28,7 @@ import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.AASXDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.AASXSerializer;
@@ -50,8 +52,11 @@ public class AASXDeserializerTest {
 
         List<InMemoryFile> fileList = new ArrayList<>();
         byte[] operationManualContent = { 0, 1, 2, 3, 4 };
+        byte[] thumbnail = { 0, 1, 2, 3, 4 };
         InMemoryFile inMemoryFile = new InMemoryFile(operationManualContent, "file:///aasx/OperatingManual.pdf");
+        InMemoryFile inMemoryFileThumbnail = new InMemoryFile(thumbnail, "file:///master/verwaltungsschale-detail-part1.png");
         fileList.add(inMemoryFile);
+        fileList.add(inMemoryFileThumbnail);
 
         File file = tempFolder.newFile("output.aasx");
 
@@ -61,6 +66,6 @@ public class AASXDeserializerTest {
         AASXDeserializer deserializer = new AASXDeserializer(in);
 
         assertEquals(AASSimple.createEnvironment(), deserializer.read());
-        assertEquals(fileList, deserializer.getRelatedFiles());
+        assertTrue(CollectionUtils.isEqualCollection(fileList, deserializer.getRelatedFiles()));
     }
 }

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
@@ -48,8 +48,11 @@ public class AASXSerializerTest {
     @Before
     public void setup() throws IOException {
         byte[] operationManualContent = { 0, 1, 2, 3, 4 };
+        byte[] thumbnail = { 0, 1, 2, 3, 4 };
         InMemoryFile file = new InMemoryFile(operationManualContent, "file:///aasx/OperatingManual.pdf");
+        InMemoryFile inMemoryFileThumbnail = new InMemoryFile(thumbnail, "file:///master/verwaltungsschale-detail-part1.png");
         fileList.add(file);
+        fileList.add(inMemoryFileThumbnail);
     }
 
     @Test


### PR DESCRIPTION
The AASXSerializer/Deserializer ignored thumbnails when loading or saving files in the AASX.
The thumbnails are now properly processed as files.