### PR TITLE
Fixes AASXDeserializer getRelatedFiles crashes

### DIFF
--- a/dataformat-aasx/pom.xml
+++ b/dataformat-aasx/pom.xml
@@ -47,5 +47,10 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>dataformat-core</artifactId>
         </dependency>
+         <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <scope>test</scope>
+            </dependency>
     </dependencies>
 </project>

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -168,7 +168,7 @@ public class AASXDeserializer {
 
     private String getXMLPart(PackagePart originPart) throws InvalidFormatException {
         if (isCompatibilityModeNeeded(originPart)) {
-            logger.warn("AASX contains wrong Relationship namespace. This may be related to a bug in AASX Package Explorer or an old version of AAS4J. Future compatibility with the wrong namespace may not be guaranteed");
+            logger.warn("AASX contains wrong Relationship namespace. This may be related to the AASX being created with an old version of AASX Package Explorer or an old version of AAS4J. Future compatibility with the wrong namespace may not be guaranteed");
             return AASPEC_RELTYPE_BACKWARDSCOMPATIBLE;
         } else {
             return AASXSerializer.AASSPEC_RELTYPE;

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -127,11 +127,11 @@ public class AASXSerializer {
                 && aas.getAssetInformation().getDefaultThumbnail() != null
                 && aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
                 .forEach(aas -> createParts(files,
-                        AASXUtils.getPathFromURL(aas.getAssetInformation().getDefaultThumbnail().getPath()),
+                        AASXUtils.removeFilePartOfURI(aas.getAssetInformation().getDefaultThumbnail().getPath()),
                         rootPackage, xmlPart, aas.getAssetInformation().getDefaultThumbnail().getContentType()));
         environment.getSubmodels().forEach(sm ->
             findFileElements(sm.getSubmodelElements()).forEach(file -> createParts(files,
-                    AASXUtils.getPathFromURL(file.getValue()), rootPackage, xmlPart, file.getContentType())));
+                    AASXUtils.removeFilePartOfURI(file.getValue()), rootPackage, xmlPart, file.getContentType())));
     }
 
     /**
@@ -265,7 +265,7 @@ public class AASXSerializer {
      */
     private InMemoryFile findFileByPath(Collection<InMemoryFile> files, String path) {
         for (InMemoryFile file : files) {
-            if (AASXUtils.getPathFromURL(file.getPath()).equals(path)) {
+            if (AASXUtils.removeFilePartOfURI(file.getPath()).equals(path)) {
                 return file;
             }
         }
@@ -279,11 +279,10 @@ public class AASXSerializer {
      * @return the prepared path
      */
     private String preparePath(String path) {
-        String newPath = AASXUtils.getPathFromURL(path);
-        if (!newPath.startsWith("file://")) {
-            newPath = "file://" + newPath;
+        if (path.startsWith("/")) {
+            path = "file://" + path;
         }
-        return newPath;
+        return path;
     }
 
 }

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/AASXUtils.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/AASXUtils.java
@@ -1,40 +1,48 @@
+/*
+ * Copyright (c) 2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.internal;
 
+/**
+ * @author schnicke
+ */
 public class AASXUtils {
 
 
     /**
-     * Gets the path from a URL e.g "http://localhost:8080/path/to/test.file"
-     * results in "/path/to/test.file"
+     * Removes the file: or file:// suffix of an URI
      *
-     * @param url URL to get the path for
-     * @return the path from the URL
+     * @param uri
+     *            URI to remove the file suffix from
+     * @return the URI without the file suffix
      */
-    public static String getPathFromURL(String url) {
-        if (url == null) {
+    public static String removeFilePartOfURI(String uri) {
+        if (uri == null) {
             return null;
         }
 
-        if (url.contains("://")) {
-
-            // Find the ":" and and remove the "http://" from the url
-            int index = url.indexOf(":") + 3;
-            url = url.substring(index);
-
-            // Find the first "/" from the URL (now without the "http://") and remove
-            // everything before that
-            index = url.indexOf("/");
-            url = url.substring(index);
-
-            // Recursive call to deal with more than one server parts
-            // (e.g. basyx://127.0.0.1:6998//https://localhost/test/)
-            return getPathFromURL(url);
-        } else {
-            // Make sure the path has a / at the start
-            if (!url.startsWith("/")) {
-                url = "/" + url;
-            }
-            return url;
+        if (uri.startsWith("file://")) {
+            return uri.replaceFirst("file://", "");
+        } else if (uri.startsWith("file:")) {
+            return uri.replaceFirst("file:", "");
         }
+
+        return uri;
+    }
+    
+    public static boolean isFilePath(String uri) {
+        return uri.startsWith("/") || uri.startsWith("file:") || uri.startsWith("./") || uri.startsWith("../");
     }
 }

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/AASXUtils.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/AASXUtils.java
@@ -15,9 +15,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.internal;
 
-/**
- * @author schnicke
- */
 public class AASXUtils {
 
 

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/TestAASXUtils.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/TestAASXUtils.java
@@ -22,9 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-/**
- * @author schnicke
- */
 public class TestAASXUtils {
 
 	@Test

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/TestAASXUtils.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/internal/TestAASXUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * @author schnicke
+ */
+public class TestAASXUtils {
+
+	@Test
+	public void isFilePath() {
+		// Cf. RFC8089
+		String[] filePaths = {
+				"file://a", "file:a", "./b/c", "../b/c/d", "/a" 
+		};
+		
+		String[] notFilePaths = {
+				"http://admin-shell.io/example", "ftp://admin-shell.io/example"
+		};
+
+		for (String filePath : filePaths) {
+			assertTrue(AASXUtils.isFilePath(filePath));
+		}
+
+		for (String filePath : notFilePaths) {
+			assertFalse(AASXUtils.isFilePath(filePath));
+		}
+	}
+
+	@Test
+	public void removeFilePartOfURI() {
+		String[] filePaths = {
+				"file:///a", "file:/a", "/a"
+		};
+
+		for (String filePath : filePaths) {
+			assertEquals("/a", AASXUtils.removeFilePartOfURI(filePath));
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
         <revision.major>1</revision.major>
         <revision.minor>0</revision.minor>
         <revision.patch>0</revision.patch>
-        <revision.suffix>-milestone-04</revision.suffix>
+        <revision.suffix>-SNAPSHOT</revision.suffix>
         <revision>${revision.major}.${revision.minor}.${revision.patch}${revision.suffix}</revision>
-        <model.version>1.0.0-milestone-04</model.version>
+        <model.version>1.0.0-SNAPSHOT</model.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
* Only file URLs are tried to resolve
* Non-existing files lead to a warning

Closes https://github.com/eclipse-aas4j/aas4j/issues/227