### PR TITLE
Allow subclass in equals in Default implementations

### DIFF
--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/CustomProperty.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/CustomProperty.java
@@ -16,201 +16,203 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.ModellingKind;
-import org.eclipse.digitaltwin.aas4j.v3.model.Property;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
 
 public class CustomProperty implements Property {
 
-	 protected List<EmbeddedDataSpecification> embeddedDataSpecifications;
+    protected List<EmbeddedDataSpecification> embeddedDataSpecifications = new LinkedList<>();
+    ;
 
-	protected List<Reference> dataSpecifications;
+    protected Reference semanticId;
 
-	protected ModellingKind kind;
+    protected String value;
 
-	protected Reference semanticId;
+    protected Reference valueId;
 
-	protected String value;
+    protected DataTypeDefXsd valueType;
 
-	protected Reference valueId;
+    protected List<Qualifier> qualifiers = new LinkedList<>();
+    ;
 
-	protected DataTypeDefXsd valueType;
+    protected String category;
 
-	protected List<Qualifier> qualifiers;
+    protected List<LangStringTextType> description = new LinkedList<>();
+    ;
 
-	protected String category;
+    protected List<LangStringNameType> displayName = new LinkedList<>();
+    ;
 
-	protected List<LangStringTextType> description;
+    protected String idShort;
 
-	protected List<LangStringNameType> displayName;
+    protected List<Extension> extensions = new LinkedList<>();
+    ;
 
-	protected String idShort;
+    protected List<Reference> supplementalSemanticIds = new LinkedList<>();
 
-	protected List<Extension> extensions;
+    protected CustomProperty() {
+    }
 
-	protected List<Reference> supplementalSemanticIds;
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.valueType,
+                this.value,
+                this.valueId,
+                this.embeddedDataSpecifications,
+                this.category,
+                this.idShort,
+                this.displayName,
+                this.description,
+                this.extensions,
+                this.semanticId,
+                this.supplementalSemanticIds,
+                this.qualifiers);
+    }
 
-	protected CustomProperty() {
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else if ((obj instanceof Property) == false) {
+            return false;
+        } else {
+            Property other = (Property) obj;
+            return Objects.equals(this.valueType, other.getValueType())
+                    && Objects.equals(this.value, other.getValue())
+                    && Objects.equals(this.valueId, other.getValueId())
+                    && Objects.equals(this.category, other.getCategory())
+                    && Objects.equals(this.description, other.getDescription())
+                    && Objects.equals(this.displayName, other.getDisplayName())
+                    && Objects.equals(this.idShort, other.getIdShort())
+                    && Objects.equals(this.qualifiers, other.getQualifiers())
+                    && Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications())
+                    && Objects.equals(this.semanticId, other.getSemanticId());
+        }
+    }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(new Object[] { this.valueType, this.value, this.valueId, this.category, this.description,
-				this.displayName, this.idShort, this.qualifiers, /* this.embeddedDataSpecifications,*/ this.kind,
-				this.semanticId });
-	}
+    @Override
+    final public DataTypeDefXsd getValueType() {
+        return this.valueType;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		} else if (obj == null) {
-			return false;
-		} else if (this.getClass() != obj.getClass()) {
-			return false;
-		} else {
-			CustomProperty other = (CustomProperty) obj;
-			return Objects.equals(this.valueType, other.valueType)
-					&& Objects.equals(this.value, other.value)
-					&& Objects.equals(this.valueId, other.valueId)
-					&& Objects.equals(this.category, other.category)
-					&& Objects.equals(this.description, other.description)
-					&& Objects.equals(this.displayName, other.displayName)
-					&& Objects.equals(this.idShort, other.idShort)
-					&& Objects.equals(this.qualifiers, other.qualifiers)
-					&& Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications)
-					&& Objects.equals(this.kind, other.kind)
-					&& Objects.equals(this.semanticId, other.semanticId);
-		}
-	}
+    @Override
+    final public void setValueType(DataTypeDefXsd dataType) {
+        this.valueType = dataType;
+    }
 
-	@Override
-	final public DataTypeDefXsd getValueType() {
-		return this.valueType;
-	}
+    @Override
+    final public String getValue() {
+        return value;
+    }
 
-	@Override
-	final public void setValueType(DataTypeDefXsd dataType) {
-		this.valueType = dataType;
-	}
+    @Override
+    final public void setValue(String value) {
+        this.value = value;
+    }
 
-	@Override
-	final public String getValue() {
-		return value;
-	}
+    @Override
+    final public Reference getValueId() {
+        return valueId;
+    }
 
-	@Override
-	final public void setValue(String value) {
-		this.value = value;
-	}
+    @Override
+    final public void setValueId(Reference valueId) {
+        this.valueId = valueId;
+    }
 
-	@Override
-	final public Reference getValueId() {
-		return valueId;
-	}
+    @Override
+    final public String getCategory() {
+        return category;
+    }
 
-	@Override
-	final public void setValueId(Reference valueId) {
-		this.valueId = valueId;
-	}
+    @Override
+    final public void setCategory(String category) {
+        this.category = category;
+    }
 
-	@Override
-	final public String getCategory() {
-		return category;
-	}
+    @Override
+    final public List<LangStringTextType> getDescription() {
+        return description;
+    }
 
-	@Override
-	final public void setCategory(String category) {
-		this.category = category;
-	}
+    @Override
+    final public void setDescription(List<LangStringTextType> description) {
+        this.description = description;
+    }
 
-	@Override
-	final public List<LangStringTextType> getDescription() {
-		return description;
-	}
+    @Override
+    final public List<LangStringNameType> getDisplayName() {
+        return displayName;
+    }
 
-	@Override
-	final public void setDescription(List<LangStringTextType> description) {
-		this.description = description;
-	}
+    @Override
+    final public void setDisplayName(List<LangStringNameType> displayName) {
+        this.displayName = displayName;
+    }
 
-	@Override
-	final public List<LangStringNameType> getDisplayName() {
-		return displayName;
-	}
+    @Override
+    final public String getIdShort() {
+        return idShort;
+    }
 
-	@Override
-	final public void setDisplayName(List<LangStringNameType> displayName) {
-		this.displayName = displayName;
-	}
+    @Override
+    final public void setIdShort(String idShort) {
+        this.idShort = idShort;
+    }
 
-	@Override
-	final public String getIdShort() {
-		return idShort;
-	}
+    @Override
+    final public List<Qualifier> getQualifiers() {
+        return qualifiers;
+    }
 
-	@Override
-	final public void setIdShort(String idShort) {
-		this.idShort = idShort;
-	}
+    @Override
+    final public void setQualifiers(List<Qualifier> qualifiers) {
+        this.qualifiers = qualifiers;
+    }
 
-	@Override
-	final public List<Qualifier> getQualifiers() {
-		return qualifiers;
-	}
+    @Override
+    final public List<EmbeddedDataSpecification> getEmbeddedDataSpecifications() {
+        return embeddedDataSpecifications;
+    }
 
-	@Override
-	final public void setQualifiers(List<Qualifier> qualifiers) {
-		this.qualifiers = qualifiers;
-	}
+    @Override
+    final public void setEmbeddedDataSpecifications(List<EmbeddedDataSpecification> embeddedDataSpecifications) {
+        this.embeddedDataSpecifications = embeddedDataSpecifications;
+    }
 
-	@Override
-	final public List<EmbeddedDataSpecification> getEmbeddedDataSpecifications() {
-		return embeddedDataSpecifications;
-	}
+    @Override
+    final public Reference getSemanticId() {
+        return semanticId;
+    }
 
-	@Override
-	final public void setEmbeddedDataSpecifications(List<EmbeddedDataSpecification> embeddedDataSpecifications) {
-		this.embeddedDataSpecifications = embeddedDataSpecifications;
-	}
+    @Override
+    final public void setSemanticId(Reference semanticId) {
+        this.semanticId = semanticId;
+    }
 
-	@Override
-	final public Reference getSemanticId() {
-		return semanticId;
-	}
+    @Override
+    public List<Reference> getSupplementalSemanticIds() {
+        return supplementalSemanticIds;
+    }
 
-	@Override
-	final public void setSemanticId(Reference semanticId) {
-		this.semanticId = semanticId;
-	}
+    @Override
+    public void setSupplementalSemanticIds(List<Reference> supplementalSemanticIds) {
+        this.supplementalSemanticIds = supplementalSemanticIds;
+    }
 
-	@Override
-	public List<Reference> getSupplementalSemanticIds() {
-		return supplementalSemanticIds;
-	}
+    @Override
+    public List<Extension> getExtensions() {
+        return extensions;
+    }
 
-	@Override
-	public void setSupplementalSemanticIds(List<Reference> supplementalSemanticIds) {
-		this.supplementalSemanticIds = supplementalSemanticIds;
-	}
-
-	@Override
-	public List<Extension> getExtensions() {
-		return extensions;
-	}
-
-	@Override
-	public void setExtensions(List<Extension> list) {
-		this.extensions = list;
-	}
+    @Override
+    public void setExtensions(List<Extension> list) {
+        this.extensions = list;
+    }
 }

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/model/ModelTest.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/model/ModelTest.java
@@ -1,0 +1,30 @@
+package org.eclipse.digitaltwin.aas4j.v3.model;
+
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.CustomSubProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProperty;
+import org.junit.Test;
+
+public class ModelTest {
+
+    void fillProperty(Property object) {
+        object.setIdShort("test");
+        object.setValueType(DataTypeDefXsd.STRING);
+    }
+
+    @Test
+    public void testPropertyEqualityWithSubclass() {
+        Property defaultProperty = new DefaultProperty();
+        Property customProperty = new CustomSubProperty();
+        fillProperty(customProperty);
+        fillProperty(defaultProperty);
+
+        //object should be equal to itself
+        assert defaultProperty.equals(defaultProperty);
+        //defaultProperty should be equal with customProperty
+        assert defaultProperty.equals(customProperty);
+        assert customProperty.equals(customProperty);
+        assert customProperty.equals(defaultProperty);
+        //hashCode implementation should be consistent
+        assert customProperty.hashCode() == defaultProperty.hashCode();
+    }
+}

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAdministrativeInformation.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAdministrativeInformation.java
@@ -68,15 +68,15 @@ public class DefaultAdministrativeInformation implements AdministrativeInformati
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof AdministrativeInformation) == false) {
             return false;
         } else {
-            DefaultAdministrativeInformation other = (DefaultAdministrativeInformation) obj;
-            return Objects.equals(this.version, other.version) &&
-                Objects.equals(this.revision, other.revision) &&
-                Objects.equals(this.creator, other.creator) &&
-                Objects.equals(this.templateId, other.templateId) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications);
+            AdministrativeInformation other = (AdministrativeInformation) obj;
+            return Objects.equals(this.version, other.getVersion()) &&
+                Objects.equals(this.revision, other.getRevision()) &&
+                Objects.equals(this.creator, other.getCreator()) &&
+                Objects.equals(this.templateId, other.getTemplateId()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAnnotatedRelationshipElement.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAnnotatedRelationshipElement.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AnnotatedRelationshipElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.DataElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.AnnotatedRelationshipElementBuilder;
 
@@ -102,22 +95,22 @@ public class DefaultAnnotatedRelationshipElement implements AnnotatedRelationshi
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof AnnotatedRelationshipElement) == false) {
             return false;
         } else {
-            DefaultAnnotatedRelationshipElement other = (DefaultAnnotatedRelationshipElement) obj;
-            return Objects.equals(this.annotations, other.annotations) &&
-                Objects.equals(this.first, other.first) &&
-                Objects.equals(this.second, other.second) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            AnnotatedRelationshipElement other = (AnnotatedRelationshipElement) obj;
+            return Objects.equals(this.annotations, other.getAnnotations()) &&
+                Objects.equals(this.first, other.getFirst()) &&
+                Objects.equals(this.second, other.getSecond()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAssetAdministrationShell.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAssetAdministrationShell.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AdministrativeInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.AssetAdministrationShellBuilder;
 
@@ -96,21 +89,21 @@ public class DefaultAssetAdministrationShell implements AssetAdministrationShell
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof AssetAdministrationShell) == false) {
             return false;
         } else {
-            DefaultAssetAdministrationShell other = (DefaultAssetAdministrationShell) obj;
-            return Objects.equals(this.derivedFrom, other.derivedFrom) &&
-                Objects.equals(this.assetInformation, other.assetInformation) &&
-                Objects.equals(this.submodels, other.submodels) &&
-                Objects.equals(this.administration, other.administration) &&
-                Objects.equals(this.id, other.id) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications);
+            AssetAdministrationShell other = (AssetAdministrationShell) obj;
+            return Objects.equals(this.derivedFrom, other.getDerivedFrom()) &&
+                Objects.equals(this.assetInformation, other.getAssetInformation()) &&
+                Objects.equals(this.submodels, other.getSubmodels()) &&
+                Objects.equals(this.administration, other.getAdministration()) &&
+                Objects.equals(this.id, other.getId()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAssetAdministrationShellDescriptor.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAssetAdministrationShellDescriptor.java
@@ -15,15 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AdministrativeInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
-import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.AssetAdministrationShellDescriptorBuilder;
 
@@ -101,22 +93,22 @@ public class DefaultAssetAdministrationShellDescriptor implements AssetAdministr
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof AssetAdministrationShellDescriptor) == false) {
             return false;
         } else {
-            DefaultAssetAdministrationShellDescriptor other = (DefaultAssetAdministrationShellDescriptor) obj;
-            return Objects.equals(this.administration, other.administration) &&
-                Objects.equals(this.assetKind, other.assetKind) &&
-                Objects.equals(this.assetType, other.assetType) &&
-                Objects.equals(this.endpoints, other.endpoints) &&
-                Objects.equals(this.globalAssetId, other.globalAssetId) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.id, other.id) &&
-                Objects.equals(this.specificAssetIds, other.specificAssetIds) &&
-                Objects.equals(this.submodelDescriptors, other.submodelDescriptors) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.extensions, other.extensions);
+            AssetAdministrationShellDescriptor other = (AssetAdministrationShellDescriptor) obj;
+            return Objects.equals(this.administration, other.getAdministration()) &&
+                Objects.equals(this.assetKind, other.getAssetKind()) &&
+                Objects.equals(this.assetType, other.getAssetType()) &&
+                Objects.equals(this.endpoints, other.getEndpoints()) &&
+                Objects.equals(this.globalAssetId, other.getGlobalAssetId()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.id, other.getId()) &&
+                Objects.equals(this.specificAssetIds, other.getSpecificAssetIds()) &&
+                Objects.equals(this.submodelDescriptors, other.getSubmodelDescriptors()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.extensions, other.getExtensions());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAssetInformation.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultAssetInformation.java
@@ -15,10 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.AssetKind;
-import org.eclipse.digitaltwin.aas4j.v3.model.Resource;
-import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.AssetInformationBuilder;
 
@@ -69,15 +66,15 @@ public class DefaultAssetInformation implements AssetInformation {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof AssetInformation) == false) {
             return false;
         } else {
-            DefaultAssetInformation other = (DefaultAssetInformation) obj;
-            return Objects.equals(this.assetKind, other.assetKind) &&
-                Objects.equals(this.globalAssetId, other.globalAssetId) &&
-                Objects.equals(this.specificAssetIds, other.specificAssetIds) &&
-                Objects.equals(this.assetType, other.assetType) &&
-                Objects.equals(this.defaultThumbnail, other.defaultThumbnail);
+            AssetInformation other = (AssetInformation) obj;
+            return Objects.equals(this.assetKind, other.getAssetKind()) &&
+                Objects.equals(this.globalAssetId, other.getGlobalAssetId()) &&
+                Objects.equals(this.specificAssetIds, other.getSpecificAssetIds()) &&
+                Objects.equals(this.assetType, other.getAssetKind()) &&
+                Objects.equals(this.defaultThumbnail, other.getDefaultThumbnail());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultBaseOperationResult.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultBaseOperationResult.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.BaseOperationResult;
 import org.eclipse.digitaltwin.aas4j.v3.model.ExecutionState;
 import org.eclipse.digitaltwin.aas4j.v3.model.Message;
@@ -58,13 +59,13 @@ public class DefaultBaseOperationResult implements BaseOperationResult {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof BaseOperationResult) == false) {
             return false;
         } else {
-            DefaultBaseOperationResult other = (DefaultBaseOperationResult) obj;
-            return Objects.equals(this.executionState, other.executionState) &&
-                Objects.equals(this.success, other.success) &&
-                Objects.equals(this.messages, other.messages);
+            BaseOperationResult other = (BaseOperationResult) obj;
+            return Objects.equals(this.executionState, other.getExecutionState()) &&
+                Objects.equals(this.success, other.getSuccess()) &&
+                Objects.equals(this.messages, other.getMessages());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultBasicEventElement.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultBasicEventElement.java
@@ -15,15 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.BasicEventElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.Direction;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.StateOfEvent;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.BasicEventElementBuilder;
 
@@ -121,27 +113,27 @@ public class DefaultBasicEventElement implements BasicEventElement {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof BasicEventElement) == false) {
             return false;
         } else {
-            DefaultBasicEventElement other = (DefaultBasicEventElement) obj;
-            return Objects.equals(this.observed, other.observed) &&
-                Objects.equals(this.direction, other.direction) &&
-                Objects.equals(this.state, other.state) &&
-                Objects.equals(this.messageTopic, other.messageTopic) &&
-                Objects.equals(this.messageBroker, other.messageBroker) &&
-                Objects.equals(this.lastUpdate, other.lastUpdate) &&
-                Objects.equals(this.minInterval, other.minInterval) &&
-                Objects.equals(this.maxInterval, other.maxInterval) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            BasicEventElement other = (BasicEventElement) obj;
+            return Objects.equals(this.observed, other.getObserved()) &&
+                Objects.equals(this.direction, other.getDirection()) &&
+                Objects.equals(this.state, other.getState()) &&
+                Objects.equals(this.messageTopic, other.getMessageTopic()) &&
+                Objects.equals(this.messageBroker, other.getMessageBroker()) &&
+                Objects.equals(this.lastUpdate, other.getLastUpdate()) &&
+                Objects.equals(this.minInterval, other.getMinInterval()) &&
+                Objects.equals(this.maxInterval, other.getMaxInterval()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultBlob.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultBlob.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.Blob;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.BlobBuilder;
 
@@ -97,21 +91,21 @@ public class DefaultBlob implements Blob {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Blob) == false) {
             return false;
         } else {
-            DefaultBlob other = (DefaultBlob) obj;
-            return Arrays.equals(this.value, other.value) &&
-                Objects.equals(this.contentType, other.contentType) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Blob other = (Blob) obj;
+            return Arrays.equals(this.value, other.getValue()) &&
+                Objects.equals(this.contentType, other.getContentType()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultCapability.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultCapability.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.Capability;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.CapabilityBuilder;
 
@@ -88,19 +82,19 @@ public class DefaultCapability implements Capability {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Capability) == false) {
             return false;
         } else {
-            DefaultCapability other = (DefaultCapability) obj;
-            return Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Capability other = (Capability) obj;
+            return Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultConceptDescription.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultConceptDescription.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AdministrativeInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.ConceptDescriptionBuilder;
 
@@ -88,19 +82,19 @@ public class DefaultConceptDescription implements ConceptDescription {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof ConceptDescription) == false) {
             return false;
         } else {
-            DefaultConceptDescription other = (DefaultConceptDescription) obj;
-            return Objects.equals(this.isCaseOf, other.isCaseOf) &&
-                Objects.equals(this.administration, other.administration) &&
-                Objects.equals(this.id, other.id) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications);
+            ConceptDescription other = (ConceptDescription) obj;
+            return Objects.equals(this.isCaseOf, other.getIsCaseOf()) &&
+                Objects.equals(this.administration, other.getAdministration()) &&
+                Objects.equals(this.id, other.getId()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultDataSpecificationIec61360.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultDataSpecificationIec61360.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.DataSpecificationIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringDefinitionTypeIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringPreferredNameTypeIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringShortNameTypeIec61360;
-import org.eclipse.digitaltwin.aas4j.v3.model.LevelType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.ValueList;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.DataSpecificationIec61360Builder;
 
@@ -102,22 +95,22 @@ public class DefaultDataSpecificationIec61360 implements DataSpecificationIec613
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof DataSpecificationIec61360) == false) {
             return false;
         } else {
-            DefaultDataSpecificationIec61360 other = (DefaultDataSpecificationIec61360) obj;
-            return Objects.equals(this.preferredName, other.preferredName) &&
-                Objects.equals(this.shortName, other.shortName) &&
-                Objects.equals(this.unit, other.unit) &&
-                Objects.equals(this.unitId, other.unitId) &&
-                Objects.equals(this.sourceOfDefinition, other.sourceOfDefinition) &&
-                Objects.equals(this.symbol, other.symbol) &&
-                Objects.equals(this.dataType, other.dataType) &&
-                Objects.equals(this.definition, other.definition) &&
-                Objects.equals(this.valueFormat, other.valueFormat) &&
-                Objects.equals(this.valueList, other.valueList) &&
-                Objects.equals(this.value, other.value) &&
-                Objects.equals(this.levelType, other.levelType);
+            DataSpecificationIec61360 other = (DataSpecificationIec61360) obj;
+            return Objects.equals(this.preferredName, other.getPreferredName()) &&
+                Objects.equals(this.shortName, other.getShortName()) &&
+                Objects.equals(this.unit, other.getUnit()) &&
+                Objects.equals(this.unitId, other.getUnitId()) &&
+                Objects.equals(this.sourceOfDefinition, other.getSourceOfDefinition()) &&
+                Objects.equals(this.symbol, other.getSymbol()) &&
+                Objects.equals(this.dataType, other.getDataType()) &&
+                Objects.equals(this.definition, other.getDefinition()) &&
+                Objects.equals(this.valueFormat, other.getValueFormat()) &&
+                Objects.equals(this.valueList, other.getValueList()) &&
+                Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.levelType, other.getLevelType());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultDescriptor.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultDescriptor.java
@@ -15,10 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.Descriptor;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.DescriptorBuilder;
 
@@ -59,13 +56,13 @@ public class DefaultDescriptor implements Descriptor {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Descriptor) == false) {
             return false;
         } else {
-            DefaultDescriptor other = (DefaultDescriptor) obj;
-            return Objects.equals(this.description, other.description) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.extensions, other.extensions);
+            Descriptor other = (Descriptor) obj;
+            return Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.extensions, other.getExtensions());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEmbeddedDataSpecification.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEmbeddedDataSpecification.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataSpecificationContent;
 import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
@@ -54,12 +55,12 @@ public class DefaultEmbeddedDataSpecification implements EmbeddedDataSpecificati
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof EmbeddedDataSpecification) == false) {
             return false;
         } else {
-            DefaultEmbeddedDataSpecification other = (DefaultEmbeddedDataSpecification) obj;
-            return Objects.equals(this.dataSpecification, other.dataSpecification) &&
-                Objects.equals(this.dataSpecificationContent, other.dataSpecificationContent);
+            EmbeddedDataSpecification other = (EmbeddedDataSpecification) obj;
+            return Objects.equals(this.dataSpecification, other.getDataSpecification()) &&
+                Objects.equals(this.dataSpecificationContent, other.getDataSpecificationContent());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEndpoint.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEndpoint.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
 import org.eclipse.digitaltwin.aas4j.v3.model.ProtocolInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -51,12 +52,12 @@ public class DefaultEndpoint implements Endpoint {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Endpoint) == false) {
             return false;
         } else {
-            DefaultEndpoint other = (DefaultEndpoint) obj;
-            return Objects.equals(this._interface, other._interface) &&
-                Objects.equals(this.protocolInformation, other.protocolInformation);
+            Endpoint other = (Endpoint) obj;
+            return Objects.equals(this._interface, other.get_interface()) &&
+                Objects.equals(this.protocolInformation, other.getProtocolInformation());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEntity.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEntity.java
@@ -15,16 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Entity;
-import org.eclipse.digitaltwin.aas4j.v3.model.EntityType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.EntityBuilder;
 
@@ -106,23 +97,23 @@ public class DefaultEntity implements Entity {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Entity) == false) {
             return false;
         } else {
-            DefaultEntity other = (DefaultEntity) obj;
-            return Objects.equals(this.statements, other.statements) &&
-                Objects.equals(this.entityType, other.entityType) &&
-                Objects.equals(this.globalAssetId, other.globalAssetId) &&
-                Objects.equals(this.specificAssetIds, other.specificAssetIds) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Entity other = (Entity) obj;
+            return Objects.equals(this.statements, other.getStatements()) &&
+                Objects.equals(this.entityType, other.getEntityType()) &&
+                Objects.equals(this.globalAssetId, other.getGlobalAssetId()) &&
+                Objects.equals(this.specificAssetIds, other.getSpecificAssetIds()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEnvironment.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEnvironment.java
@@ -60,13 +60,13 @@ public class DefaultEnvironment implements Environment {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Environment) == false) {
             return false;
         } else {
-            DefaultEnvironment other = (DefaultEnvironment) obj;
-            return Objects.equals(this.assetAdministrationShells, other.assetAdministrationShells) &&
-                Objects.equals(this.submodels, other.submodels) &&
-                Objects.equals(this.conceptDescriptions, other.conceptDescriptions);
+            Environment other = (Environment) obj;
+            return Objects.equals(this.assetAdministrationShells, other.getAssetAdministrationShells()) &&
+                Objects.equals(this.submodels, other.getSubmodels()) &&
+                Objects.equals(this.conceptDescriptions, other.getConceptDescriptions());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEventPayload.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultEventPayload.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.EventPayload;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -77,18 +78,18 @@ public class DefaultEventPayload implements EventPayload {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof EventPayload) == false) {
             return false;
         } else {
-            DefaultEventPayload other = (DefaultEventPayload) obj;
-            return Objects.equals(this.source, other.source) &&
-                Objects.equals(this.sourceSemanticId, other.sourceSemanticId) &&
-                Objects.equals(this.observableReference, other.observableReference) &&
-                Objects.equals(this.observableSemanticId, other.observableSemanticId) &&
-                Objects.equals(this.topic, other.topic) &&
-                Objects.equals(this.subjectId, other.subjectId) &&
-                Objects.equals(this.timeStamp, other.timeStamp) &&
-                Arrays.equals(this.payload, other.payload);
+            EventPayload other = (EventPayload) obj;
+            return Objects.equals(this.source, other.getSource()) &&
+                Objects.equals(this.sourceSemanticId, other.getSourceSemanticId()) &&
+                Objects.equals(this.observableReference, other.getObservableReference()) &&
+                Objects.equals(this.observableSemanticId, other.getObservableSemanticId()) &&
+                Objects.equals(this.topic, other.getTopic()) &&
+                Objects.equals(this.subjectId, other.getSubjectId()) &&
+                Objects.equals(this.timeStamp, other.getTimeStamp()) &&
+                Arrays.equals(this.payload, other.getPayload());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultExtension.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultExtension.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
 import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
@@ -71,16 +72,16 @@ public class DefaultExtension implements Extension {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Extension) == false) {
             return false;
         } else {
-            DefaultExtension other = (DefaultExtension) obj;
-            return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.valueType, other.valueType) &&
-                Objects.equals(this.value, other.value) &&
-                Objects.equals(this.refersTo, other.refersTo) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds);
+            Extension other = (Extension) obj;
+            return Objects.equals(this.name, other.getName()) &&
+                Objects.equals(this.valueType, other.getValueType()) &&
+                Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.refersTo, other.getRefersTo()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultFile.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultFile.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.File;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.FileBuilder;
 
@@ -95,21 +89,21 @@ public class DefaultFile implements File {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof File) == false) {
             return false;
         } else {
-            DefaultFile other = (DefaultFile) obj;
-            return Objects.equals(this.value, other.value) &&
-                Objects.equals(this.contentType, other.contentType) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            File other = (File) obj;
+            return Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.contentType, other.getContentType()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultKey.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultKey.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -52,12 +53,12 @@ public class DefaultKey implements Key {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Key) == false) {
             return false;
         } else {
-            DefaultKey other = (DefaultKey) obj;
-            return Objects.equals(this.type, other.type) &&
-                Objects.equals(this.value, other.value);
+            Key other = (Key) obj;
+            return Objects.equals(this.type, other.getType()) &&
+                Objects.equals(this.value, other.getValue());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringDefinitionTypeIec61360.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringDefinitionTypeIec61360.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringDefinitionTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.LangStringDefinitionTypeIec61360Builder;
@@ -52,12 +53,12 @@ public class DefaultLangStringDefinitionTypeIec61360 implements LangStringDefini
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof LangStringDefinitionTypeIec61360) == false) {
             return false;
         } else {
-            DefaultLangStringDefinitionTypeIec61360 other = (DefaultLangStringDefinitionTypeIec61360) obj;
-            return Objects.equals(this.language, other.language) &&
-                Objects.equals(this.text, other.text);
+            LangStringDefinitionTypeIec61360 other = (LangStringDefinitionTypeIec61360) obj;
+            return Objects.equals(this.language, other.getLanguage()) &&
+                Objects.equals(this.text, other.getText());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringNameType.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringNameType.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.LangStringNameTypeBuilder;
@@ -51,12 +52,12 @@ public class DefaultLangStringNameType implements LangStringNameType {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof LangStringNameType) == false) {
             return false;
         } else {
-            DefaultLangStringNameType other = (DefaultLangStringNameType) obj;
-            return Objects.equals(this.language, other.language) &&
-                Objects.equals(this.text, other.text);
+            LangStringNameType other = (LangStringNameType) obj;
+            return Objects.equals(this.language, other.getLanguage()) &&
+                Objects.equals(this.text, other.getText());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringPreferredNameTypeIec61360.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringPreferredNameTypeIec61360.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringPreferredNameTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.LangStringPreferredNameTypeIec61360Builder;
@@ -52,12 +53,12 @@ public class DefaultLangStringPreferredNameTypeIec61360 implements LangStringPre
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof LangStringPreferredNameTypeIec61360) == false) {
             return false;
         } else {
-            DefaultLangStringPreferredNameTypeIec61360 other = (DefaultLangStringPreferredNameTypeIec61360) obj;
-            return Objects.equals(this.language, other.language) &&
-                Objects.equals(this.text, other.text);
+            LangStringPreferredNameTypeIec61360 other = (LangStringPreferredNameTypeIec61360) obj;
+            return Objects.equals(this.language, other.getLanguage()) &&
+                Objects.equals(this.text, other.getText());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringShortNameTypeIec61360.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringShortNameTypeIec61360.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringShortNameTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.LangStringShortNameTypeIec61360Builder;
@@ -52,12 +53,12 @@ public class DefaultLangStringShortNameTypeIec61360 implements LangStringShortNa
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof LangStringShortNameTypeIec61360) == false) {
             return false;
         } else {
-            DefaultLangStringShortNameTypeIec61360 other = (DefaultLangStringShortNameTypeIec61360) obj;
-            return Objects.equals(this.language, other.language) &&
-                Objects.equals(this.text, other.text);
+            LangStringShortNameTypeIec61360 other = (LangStringShortNameTypeIec61360) obj;
+            return Objects.equals(this.language, other.getLanguage()) &&
+                Objects.equals(this.text, other.getText());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringTextType.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLangStringTextType.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.LangStringTextTypeBuilder;
@@ -51,12 +52,12 @@ public class DefaultLangStringTextType implements LangStringTextType {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof LangStringTextType) == false) {
             return false;
         } else {
-            DefaultLangStringTextType other = (DefaultLangStringTextType) obj;
-            return Objects.equals(this.language, other.language) &&
-                Objects.equals(this.text, other.text);
+            LangStringTextType other = (LangStringTextType) obj;
+            return Objects.equals(this.language, other.getLanguage()) &&
+                Objects.equals(this.text, other.getText());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLevelType.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultLevelType.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.LevelType;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.LevelTypeBuilder;
@@ -60,14 +61,14 @@ public class DefaultLevelType implements LevelType {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof LevelType) == false) {
             return false;
         } else {
-            DefaultLevelType other = (DefaultLevelType) obj;
-            return Objects.equals(this.min, other.min) &&
-                Objects.equals(this.nom, other.nom) &&
-                Objects.equals(this.typ, other.typ) &&
-                Objects.equals(this.max, other.max);
+            LevelType other = (LevelType) obj;
+            return Objects.equals(this.min, other.getMin()) &&
+                Objects.equals(this.nom, other.getNom()) &&
+                Objects.equals(this.typ, other.getTyp()) &&
+                Objects.equals(this.max, other.getMax());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultMessage.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultMessage.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Message;
 import org.eclipse.digitaltwin.aas4j.v3.model.MessageTypeEnum;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -63,7 +64,7 @@ public class DefaultMessage implements Message {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Message) == false) {
             return false;
         } else {
             DefaultMessage other = (DefaultMessage) obj;

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultMultiLanguageProperty.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultMultiLanguageProperty.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.MultiLanguagePropertyBuilder;
 
@@ -95,21 +89,21 @@ public class DefaultMultiLanguageProperty implements MultiLanguageProperty {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof MultiLanguageProperty) == false) {
             return false;
         } else {
-            DefaultMultiLanguageProperty other = (DefaultMultiLanguageProperty) obj;
-            return Objects.equals(this.value, other.value) &&
-                Objects.equals(this.valueId, other.valueId) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            MultiLanguageProperty other = (MultiLanguageProperty) obj;
+            return Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.valueId, other.getValueId()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperation.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperation.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Operation;
-import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.OperationBuilder;
 
@@ -100,22 +93,22 @@ public class DefaultOperation implements Operation {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Operation) == false) {
             return false;
         } else {
-            DefaultOperation other = (DefaultOperation) obj;
-            return Objects.equals(this.inputVariables, other.inputVariables) &&
-                Objects.equals(this.outputVariables, other.outputVariables) &&
-                Objects.equals(this.inoutputVariables, other.inoutputVariables) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Operation other = (Operation) obj;
+            return Objects.equals(this.inputVariables, other.getInputVariables()) &&
+                Objects.equals(this.outputVariables, other.getOutputVariables()) &&
+                Objects.equals(this.inoutputVariables, other.getInoutputVariables()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSemanticId()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationHandle.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationHandle.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationHandle;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.OperationHandleBuilder;
@@ -46,11 +47,11 @@ public class DefaultOperationHandle implements OperationHandle {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof OperationHandle) == false) {
             return false;
         } else {
-            DefaultOperationHandle other = (DefaultOperationHandle) obj;
-            return Objects.equals(this.handleId, other.handleId);
+            OperationHandle other = (OperationHandle) obj;
+            return Objects.equals(this.handleId, other.getHandleId());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationRequest.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationRequest.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationRequest;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -58,13 +59,13 @@ public class DefaultOperationRequest implements OperationRequest {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof OperationRequest) == false) {
             return false;
         } else {
-            DefaultOperationRequest other = (DefaultOperationRequest) obj;
-            return Objects.equals(this.inoutputArguments, other.inoutputArguments) &&
-                Objects.equals(this.inputArguments, other.inputArguments) &&
-                Objects.equals(this.clientTimeoutDuration, other.clientTimeoutDuration);
+            OperationRequest other = (OperationRequest) obj;
+            return Objects.equals(this.inoutputArguments, other.getInoutputArguments()) &&
+                Objects.equals(this.inputArguments, other.getInputArguments()) &&
+                Objects.equals(this.clientTimeoutDuration, other.getClientTimeoutDuration());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationResult.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationResult.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationResult;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -53,12 +54,12 @@ public class DefaultOperationResult implements OperationResult {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof OperationResult) == false) {
             return false;
         } else {
-            DefaultOperationResult other = (DefaultOperationResult) obj;
-            return Objects.equals(this.inoutputArguments, other.inoutputArguments) &&
-                Objects.equals(this.outputArguments, other.outputArguments);
+            OperationResult other = (OperationResult) obj;
+            return Objects.equals(this.inoutputArguments, other.getInoutputArguments()) &&
+                Objects.equals(this.outputArguments, other.getOutputArguments());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationVariable.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultOperationVariable.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -49,11 +50,11 @@ public class DefaultOperationVariable implements OperationVariable {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof OperationVariable) == false) {
             return false;
         } else {
-            DefaultOperationVariable other = (DefaultOperationVariable) obj;
-            return Objects.equals(this.value, other.value);
+            OperationVariable other = (OperationVariable) obj;
+            return Objects.equals(this.value, other.getValue());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultPackageDescription.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultPackageDescription.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.PackageDescription;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.PackageDescriptionBuilder;
@@ -52,12 +53,12 @@ public class DefaultPackageDescription implements PackageDescription {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof PackageDescription) == false) {
             return false;
         } else {
-            DefaultPackageDescription other = (DefaultPackageDescription) obj;
-            return Objects.equals(this.items, other.items) &&
-                Objects.equals(this.packageId, other.packageId);
+            PackageDescription other = (PackageDescription) obj;
+            return Objects.equals(this.items, other.getItems()) &&
+                Objects.equals(this.packageId, other.getPackageId());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultProperty.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultProperty.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Property;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.PropertyBuilder;
 
@@ -100,22 +93,22 @@ public class DefaultProperty implements Property {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Property) == false) {
             return false;
         } else {
-            DefaultProperty other = (DefaultProperty) obj;
-            return Objects.equals(this.valueType, other.valueType) &&
-                Objects.equals(this.value, other.value) &&
-                Objects.equals(this.valueId, other.valueId) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Property other = (Property) obj;
+            return Objects.equals(this.valueType, other.getValueType()) &&
+                Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.valueId, other.getValueId()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultProtocolInformation.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultProtocolInformation.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.ProtocolInformation;
 import org.eclipse.digitaltwin.aas4j.v3.model.SecurityAttributeObject;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -73,17 +74,17 @@ public class DefaultProtocolInformation implements ProtocolInformation {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof ProtocolInformation) == false) {
             return false;
         } else {
-            DefaultProtocolInformation other = (DefaultProtocolInformation) obj;
-            return Objects.equals(this.href, other.href) &&
-                Objects.equals(this.endpointProtocol, other.endpointProtocol) &&
-                Objects.equals(this.endpointProtocolVersion, other.endpointProtocolVersion) &&
-                Objects.equals(this.subprotocol, other.subprotocol) &&
-                Objects.equals(this.subprotocolBody, other.subprotocolBody) &&
-                Objects.equals(this.subprotocolBodyEncoding, other.subprotocolBodyEncoding) &&
-                Objects.equals(this.securityAttributes, other.securityAttributes);
+            ProtocolInformation other = (ProtocolInformation) obj;
+            return Objects.equals(this.href, other.getHref()) &&
+                Objects.equals(this.endpointProtocol, other.getEndpointProtocol()) &&
+                Objects.equals(this.endpointProtocolVersion, other.getEndpointProtocolVersion()) &&
+                Objects.equals(this.subprotocol, other.getSubprotocol()) &&
+                Objects.equals(this.subprotocolBody, other.getSubprotocolBody()) &&
+                Objects.equals(this.subprotocolBodyEncoding, other.getSubprotocolBodyEncoding()) &&
+                Objects.equals(this.securityAttributes, other.getSecurityAttributes());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultQualifier.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultQualifier.java
@@ -15,10 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.QualifierKind;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.QualifierBuilder;
 
@@ -79,17 +76,17 @@ public class DefaultQualifier implements Qualifier {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Qualifier) == false) {
             return false;
         } else {
-            DefaultQualifier other = (DefaultQualifier) obj;
-            return Objects.equals(this.kind, other.kind) &&
-                Objects.equals(this.type, other.type) &&
-                Objects.equals(this.valueType, other.valueType) &&
-                Objects.equals(this.value, other.value) &&
-                Objects.equals(this.valueId, other.valueId) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds);
+            Qualifier other = (Qualifier) obj;
+            return Objects.equals(this.kind, other.getKind()) &&
+                Objects.equals(this.type, other.getType()) &&
+                Objects.equals(this.valueType, other.getValueType()) &&
+                Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.valueId, other.getValueId()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultRange.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultRange.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Range;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.RangeBuilder;
 
@@ -100,22 +93,22 @@ public class DefaultRange implements Range {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Range) == false) {
             return false;
         } else {
-            DefaultRange other = (DefaultRange) obj;
-            return Objects.equals(this.valueType, other.valueType) &&
-                Objects.equals(this.min, other.min) &&
-                Objects.equals(this.max, other.max) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Range other = (Range) obj;
+            return Objects.equals(this.valueType, other.getValueType()) &&
+                Objects.equals(this.min, other.getMin()) &&
+                Objects.equals(this.max, other.getMax()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultReference.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultReference.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceTypes;
@@ -59,13 +60,13 @@ public class DefaultReference implements Reference {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Reference) == false) {
             return false;
         } else {
-            DefaultReference other = (DefaultReference) obj;
-            return Objects.equals(this.type, other.type) &&
-                Objects.equals(this.referredSemanticId, other.referredSemanticId) &&
-                Objects.equals(this.keys, other.keys);
+            Reference other = (Reference) obj;
+            return Objects.equals(this.type, other.getType()) &&
+                Objects.equals(this.referredSemanticId, other.getReferredSemanticId()) &&
+                Objects.equals(this.keys, other.getKeys());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultReferenceElement.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultReferenceElement.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.ReferenceElementBuilder;
 
@@ -92,20 +86,20 @@ public class DefaultReferenceElement implements ReferenceElement {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof ReferenceElement) == false) {
             return false;
         } else {
-            DefaultReferenceElement other = (DefaultReferenceElement) obj;
-            return Objects.equals(this.value, other.value) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            ReferenceElement other = (ReferenceElement) obj;
+            return Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultRelationshipElement.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultRelationshipElement.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.RelationshipElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.RelationshipElementBuilder;
 
@@ -96,21 +90,21 @@ public class DefaultRelationshipElement implements RelationshipElement {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof RelationshipElement) == false) {
             return false;
         } else {
-            DefaultRelationshipElement other = (DefaultRelationshipElement) obj;
-            return Objects.equals(this.first, other.first) &&
-                Objects.equals(this.second, other.second) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            RelationshipElement other = (RelationshipElement) obj;
+            return Objects.equals(this.first, other.getFirst()) &&
+                Objects.equals(this.second, other.getSecond()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultResource.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultResource.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Resource;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.ResourceBuilder;
@@ -52,12 +53,12 @@ public class DefaultResource implements Resource {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Resource) == false) {
             return false;
         } else {
-            DefaultResource other = (DefaultResource) obj;
-            return Objects.equals(this.path, other.path) &&
-                Objects.equals(this.contentType, other.contentType);
+            Resource other = (Resource) obj;
+            return Objects.equals(this.path, other.getPath()) &&
+                Objects.equals(this.contentType, other.getContentType());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultResult.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultResult.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Message;
 import org.eclipse.digitaltwin.aas4j.v3.model.Result;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -49,11 +50,11 @@ public class DefaultResult implements Result {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Result) == false) {
             return false;
         } else {
-            DefaultResult other = (DefaultResult) obj;
-            return Objects.equals(this.messages, other.messages);
+            Result other = (Result) obj;
+            return Objects.equals(this.messages, other.getMessages());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSecurityAttributeObject.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSecurityAttributeObject.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.SecurityAttributeObject;
 import org.eclipse.digitaltwin.aas4j.v3.model.SecurityTypeEnum;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -55,13 +56,13 @@ public class DefaultSecurityAttributeObject implements SecurityAttributeObject {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof SecurityAttributeObject) == false) {
             return false;
         } else {
-            DefaultSecurityAttributeObject other = (DefaultSecurityAttributeObject) obj;
-            return Objects.equals(this.type, other.type) &&
-                Objects.equals(this.key, other.key) &&
-                Objects.equals(this.value, other.value);
+            SecurityAttributeObject other = (SecurityAttributeObject) obj;
+            return Objects.equals(this.type, other.getType()) &&
+                Objects.equals(this.key, other.getKey()) &&
+                Objects.equals(this.value, other.getValue());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSpecificAssetId.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSpecificAssetId.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -66,15 +67,15 @@ public class DefaultSpecificAssetId implements SpecificAssetId {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof SpecificAssetId) == false) {
             return false;
         } else {
-            DefaultSpecificAssetId other = (DefaultSpecificAssetId) obj;
-            return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.value, other.value) &&
-                Objects.equals(this.externalSubjectId, other.externalSubjectId) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds);
+            SpecificAssetId other = (SpecificAssetId) obj;
+            return Objects.equals(this.name, other.getName()) &&
+                Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.externalSubjectId, other.getExternalSubjectId()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodel.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodel.java
@@ -15,16 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AdministrativeInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.ModellingKind;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.SubmodelBuilder;
 
@@ -108,23 +99,23 @@ public class DefaultSubmodel implements Submodel {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof Submodel) == false) {
             return false;
         } else {
-            DefaultSubmodel other = (DefaultSubmodel) obj;
-            return Objects.equals(this.submodelElements, other.submodelElements) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.kind, other.kind) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.administration, other.administration) &&
-                Objects.equals(this.id, other.id) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            Submodel other = (Submodel) obj;
+            return Objects.equals(this.submodelElements, other.getSubmodelElements()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.kind, other.getKind()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSemanticId()) &&
+                Objects.equals(this.administration, other.getAdministration()) &&
+                Objects.equals(this.id, other.getId()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodelDescriptor.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodelDescriptor.java
@@ -15,13 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AdministrativeInformation;
-import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.SubmodelDescriptorBuilder;
 
@@ -86,19 +80,19 @@ public class DefaultSubmodelDescriptor implements SubmodelDescriptor {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof SubmodelDescriptor) == false) {
             return false;
         } else {
-            DefaultSubmodelDescriptor other = (DefaultSubmodelDescriptor) obj;
-            return Objects.equals(this.administration, other.administration) &&
-                Objects.equals(this.endpoints, other.endpoints) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.id, other.id) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticId, other.supplementalSemanticId) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.extensions, other.extensions);
+            SubmodelDescriptor other = (SubmodelDescriptor) obj;
+            return Objects.equals(this.administration, other.getAdministration()) &&
+                Objects.equals(this.endpoints, other.getEndpoints()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.id, other.getId()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticId, other.getSupplementalSemanticId()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.extensions, other.getExtensions());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodelElementCollection.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodelElementCollection.java
@@ -15,14 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.SubmodelElementCollectionBuilder;
 
@@ -94,20 +87,20 @@ public class DefaultSubmodelElementCollection implements SubmodelElementCollecti
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof SubmodelElementCollection) == false) {
             return false;
         } else {
-            DefaultSubmodelElementCollection other = (DefaultSubmodelElementCollection) obj;
-            return Objects.equals(this.value, other.value) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers);
+            SubmodelElementCollection other = (SubmodelElementCollection) obj;
+            return Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodelElementList.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultSubmodelElementList.java
@@ -15,16 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
-import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
-import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
-import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
-import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
-import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
-import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
-import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
+import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
 import org.eclipse.digitaltwin.aas4j.v3.model.builder.SubmodelElementListBuilder;
 
@@ -112,24 +103,24 @@ public class DefaultSubmodelElementList implements SubmodelElementList {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof SubmodelElementList) == false) {
             return false;
         } else {
-            DefaultSubmodelElementList other = (DefaultSubmodelElementList) obj;
-            return Objects.equals(this.orderRelevant, other.orderRelevant) &&
-                Objects.equals(this.semanticIdListElement, other.semanticIdListElement) &&
-                Objects.equals(this.typeValueListElement, other.typeValueListElement) &&
-                Objects.equals(this.valueTypeListElement, other.valueTypeListElement) &&
-                Objects.equals(this.value, other.value) &&
-                Objects.equals(this.embeddedDataSpecifications, other.embeddedDataSpecifications) &&
-                Objects.equals(this.semanticId, other.semanticId) &&
-                Objects.equals(this.supplementalSemanticIds, other.supplementalSemanticIds) &&
-                Objects.equals(this.qualifiers, other.qualifiers) &&
-                Objects.equals(this.category, other.category) &&
-                Objects.equals(this.idShort, other.idShort) &&
-                Objects.equals(this.displayName, other.displayName) &&
-                Objects.equals(this.description, other.description) &&
-                Objects.equals(this.extensions, other.extensions);
+            SubmodelElementList other = (SubmodelElementList) obj;
+            return Objects.equals(this.orderRelevant, other.getOrderRelevant()) &&
+                Objects.equals(this.semanticIdListElement, other.getSemanticIdListElement()) &&
+                Objects.equals(this.typeValueListElement, other.getTypeValueListElement()) &&
+                Objects.equals(this.valueTypeListElement, other.getValueTypeListElement()) &&
+                Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.embeddedDataSpecifications, other.getEmbeddedDataSpecifications()) &&
+                Objects.equals(this.semanticId, other.getSemanticId()) &&
+                Objects.equals(this.supplementalSemanticIds, other.getSupplementalSemanticIds()) &&
+                Objects.equals(this.qualifiers, other.getQualifiers()) &&
+                Objects.equals(this.category, other.getCategory()) &&
+                Objects.equals(this.idShort, other.getIdShort()) &&
+                Objects.equals(this.displayName, other.getDisplayName()) &&
+                Objects.equals(this.description, other.getDescription()) &&
+                Objects.equals(this.extensions, other.getExtensions());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultValueList.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultValueList.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.ValueList;
 import org.eclipse.digitaltwin.aas4j.v3.model.ValueReferencePair;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -50,11 +51,11 @@ public class DefaultValueList implements ValueList {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof ValueList) == false) {
             return false;
         } else {
-            DefaultValueList other = (DefaultValueList) obj;
-            return Objects.equals(this.valueReferencePairs, other.valueReferencePairs);
+            ValueList other = (ValueList) obj;
+            return Objects.equals(this.valueReferencePairs, other.getValueReferencePairs());
         }
     }
 

--- a/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultValueReferencePair.java
+++ b/model/src/main/java/org/eclipse/digitaltwin/aas4j/v3/model/impl/DefaultValueReferencePair.java
@@ -15,6 +15,7 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.model.impl;
 
+import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.ValueReferencePair;
 import org.eclipse.digitaltwin.aas4j.v3.model.annotations.IRI;
@@ -53,12 +54,12 @@ public class DefaultValueReferencePair implements ValueReferencePair {
             return true;
         } else if (obj == null) {
             return false;
-        } else if (this.getClass() != obj.getClass()) {
+        } else if ((obj instanceof ValueReferencePair) == false) {
             return false;
         } else {
-            DefaultValueReferencePair other = (DefaultValueReferencePair) obj;
-            return Objects.equals(this.value, other.value) &&
-                Objects.equals(this.valueId, other.valueId);
+            ValueReferencePair other = (ValueReferencePair) obj;
+            return Objects.equals(this.value, other.getValue()) &&
+                Objects.equals(this.valueId, other.getValueId());
         }
     }
 


### PR DESCRIPTION

The current implementation of `equals` function is too restrict and does not allow comparing different subclasses of an entity to be comparable. This PR solves this. However, it does not solve the ordering of collections mentioned in [#50](https://github.com/eclipse-aas4j/aas4j/issues/50)

Furthermore, the motivation behind allowing custom subclasses should be explained, and such implementation considerations should be explained.
