### PR TITLE
[Bugfix] Files in SubmodelElementLists and NullPointerException when serializing/deserializing empty files

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -33,6 +33,7 @@ import org.apache.poi.openxml4j.opc.PackageRelationshipCollection;
 import org.apache.poi.openxml4j.opc.PackagingURIHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.internal.AASXUtils;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.visitor.AssetAdministrationShellElementWalkerVisitor;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.XmlDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.File;
@@ -207,27 +208,14 @@ public class AASXDeserializer {
                         && aas.getAssetInformation().getDefaultThumbnail() != null
                         && aas.getAssetInformation().getDefaultThumbnail().getPath() != null)
                 .forEach(aas -> paths.add(aas.getAssetInformation().getDefaultThumbnail().getPath()));
-        environment.getSubmodels().forEach(sm -> paths.addAll(parseElements(sm.getSubmodelElements())));
-        return paths;
-    }
-
-    /**
-     * Gets the file paths from a collection of ISubmodelElement
-     * 
-     * @param elements the submodel elements to process
-     * @return the Paths from the File elements
-     */
-    private List<String> parseElements(Collection<SubmodelElement> elements) {
-        List<String> paths = new ArrayList<>();
-        for (SubmodelElement element : elements) {
-            if (element instanceof File) {
-                File file = (File) element;
-                paths.add(file.getValue());
-            } else if (element instanceof SubmodelElementCollection) {
-                SubmodelElementCollection collection = (SubmodelElementCollection) element;
-                paths.addAll(parseElements(collection.getValue()));
+        new AssetAdministrationShellElementWalkerVisitor() {
+            @Override
+            public void visit(File file) {
+                if(file != null && file.getValue() != null) {
+                    paths.add(file.getValue());
+                }
             }
-        }
+        }.visit(environment);
         return paths;
     }
 

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -21,7 +21,6 @@ import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,8 +36,6 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.visitor.AssetAd
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.XmlDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.File;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -37,9 +37,6 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.visitor.AssetAd
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.XmlSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.File;
-import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
-import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -226,7 +223,7 @@ public class AASXSerializer {
     }
 
     /**
-     * Gets the File elements from a environment
+     * Gets the File elements from an environment
      * searches in SubmodelElementCollections
      * 
      * @param environment the Environment

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/AASXDeserializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/AASXDeserializerTest.java
@@ -44,6 +44,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultEnvironment;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultFile;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementList;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -89,6 +90,37 @@ public class AASXDeserializerTest {
         InputStream in = new FileInputStream(file);
         AASXDeserializer deserializer = new AASXDeserializer(in);
 
+        assertEquals(Collections.singletonList(inMemoryFile), deserializer.getRelatedFiles());
+    }
+
+    @Test
+    public void emptyFiles() throws IOException, SerializationException, InvalidFormatException, DeserializationException {
+        File emptyFile = new DefaultFile.Builder().idShort("emptyFile").contentType("").value("").build();
+        Submodel fileSm = new DefaultSubmodel.Builder().id("doesNotMatter").submodelElements(emptyFile).build();
+        Environment env = new DefaultEnvironment.Builder().submodels(fileSm).build();
+
+        java.io.File file = tempFolder.newFile("output.aasx");
+        new AASXSerializer().write(env, null, new FileOutputStream(file));
+
+        InputStream in = new FileInputStream(file);
+        AASXDeserializer deserializer = new AASXDeserializer(in);
+        assertTrue(deserializer.getRelatedFiles().isEmpty());
+    }
+
+    @Test
+    public void filesInElementList() throws IOException, SerializationException, InvalidFormatException, DeserializationException {
+        DefaultSubmodelElementList elementList = new DefaultSubmodelElementList.Builder().value(createFileSubmodelElements()).build();
+        Submodel fileSm = new DefaultSubmodel.Builder().id("doesNotMatter").submodelElements(elementList).build();
+        Environment env = new DefaultEnvironment.Builder().submodels(fileSm).build();
+
+        byte[] image = { 0, 1, 2, 3, 4 };
+        InMemoryFile inMemoryFile = new InMemoryFile(image, "file:///aasx/internalFile.jpg");
+
+        java.io.File file = tempFolder.newFile("output.aasx");
+        new AASXSerializer().write(env, Collections.singleton(inMemoryFile), new FileOutputStream(file));
+
+        InputStream in = new FileInputStream(file);
+        AASXDeserializer deserializer = new AASXDeserializer(in);
         assertEquals(Collections.singletonList(inMemoryFile), deserializer.getRelatedFiles());
     }
 

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/AASXDeserializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/AASXDeserializerTest.java
@@ -95,7 +95,7 @@ public class AASXDeserializerTest {
 
     @Test
     public void emptyFiles() throws IOException, SerializationException, InvalidFormatException, DeserializationException {
-        File emptyFile = new DefaultFile.Builder().idShort("emptyFile").contentType("").value("").build();
+        File emptyFile = new DefaultFile.Builder().idShort("emptyFile").contentType(null).value(null).build();
         Submodel fileSm = new DefaultSubmodel.Builder().id("doesNotMatter").submodelElements(emptyFile).build();
         Environment env = new DefaultEnvironment.Builder().submodels(fileSm).build();
 

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
@@ -21,7 +21,6 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.InMemoryFile;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.AASFull;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.AASSimple;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
-import org.junit.Before;
 import org.junit.Test;
 
 import javax.xml.parsers.ParserConfigurationException;

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
@@ -44,21 +44,11 @@ public class AASXSerializerTest {
 
     private List<InMemoryFile> fileList = new ArrayList<>();
 
-    @Before
-    public void setup() throws IOException {
-        byte[] operationManualContent = { 0, 1, 2, 3, 4 };
-        byte[] thumbnail = { 0, 1, 2, 3, 4 };
-        InMemoryFile file = new InMemoryFile(operationManualContent, "file:///TestFile.pdf");
-        InMemoryFile file2 = new InMemoryFile(operationManualContent, "file:///TestFile2.pdf");
-        InMemoryFile inMemoryFileThumbnail = new InMemoryFile(thumbnail, "file:///master/verwaltungsschale-detail-part1.png");
-        fileList.add(file);
-        fileList.add(file2);
-        fileList.add(inMemoryFileThumbnail);
-    }
-
     @Test
-    public void testBuildAASX() throws IOException, TransformerException, ParserConfigurationException, SerializationException {
-
+    public void testBuildAASXFull() throws IOException, TransformerException, ParserConfigurationException, SerializationException {
+        byte[] operationManualContent = { 0, 1, 2, 3, 4 };
+        InMemoryFile file = new InMemoryFile(operationManualContent, "file:///TestFile.pdf");
+        fileList.add(file);
         // This stream can be used to write the .aasx directly to a file
         // FileOutputStream out = new FileOutputStream("path/to/test.aasx");
 
@@ -66,6 +56,25 @@ public class AASXSerializerTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         new AASXSerializer().write(AASFull.createEnvironment(), fileList, out);
+
+        validateAASX(out);
+    }
+
+    @Test
+    public void testBuildAASXSimple() throws IOException, TransformerException, ParserConfigurationException, SerializationException {
+        byte[] thumbnail = { 0, 1, 2, 3, 4 };
+        byte[] operationManualContent = { 0, 1, 2, 3, 4 };
+        InMemoryFile file = new InMemoryFile(operationManualContent, "file:///aasx/OperatingManual.pdf");
+        InMemoryFile inMemoryFileThumbnail = new InMemoryFile(thumbnail, "file:///master/verwaltungsschale-detail-part1.png");
+        fileList.add(file);
+        fileList.add(inMemoryFileThumbnail);
+        // This stream can be used to write the .aasx directly to a file
+        // FileOutputStream out = new FileOutputStream("path/to/test.aasx");
+
+        // This stream keeps the output of the AASXFactory only in memory
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        new AASXSerializer().write(AASSimple.createEnvironment(), fileList, out);
 
         validateAASX(out);
     }

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
@@ -48,9 +48,11 @@ public class AASXSerializerTest {
     public void setup() throws IOException {
         byte[] operationManualContent = { 0, 1, 2, 3, 4 };
         byte[] thumbnail = { 0, 1, 2, 3, 4 };
-        InMemoryFile file = new InMemoryFile(operationManualContent, "file:///aasx/OperatingManual.pdf");
+        InMemoryFile file = new InMemoryFile(operationManualContent, "file:///TestFile.pdf");
+        InMemoryFile file2 = new InMemoryFile(operationManualContent, "file:///TestFile2.pdf");
         InMemoryFile inMemoryFileThumbnail = new InMemoryFile(thumbnail, "file:///master/verwaltungsschale-detail-part1.png");
         fileList.add(file);
+        fileList.add(file2);
         fileList.add(inMemoryFileThumbnail);
     }
 

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
@@ -18,6 +18,7 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.serialization;
 
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.AASXSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.InMemoryFile;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.AASFull;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.AASSimple;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
 import org.junit.Before;
@@ -62,7 +63,7 @@ public class AASXSerializerTest {
         // This stream keeps the output of the AASXFactory only in memory
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        new AASXSerializer().write(AASSimple.createEnvironment(), fileList, out);
+        new AASXSerializer().write(AASFull.createEnvironment(), fileList, out);
 
         validateAASX(out);
     }

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
@@ -88,8 +88,6 @@ public class AASFull {
     public final static ConceptDescription CONCEPT_DESCRIPTION_4 = createConceptDescription4();
     public static final Environment ENVIRONMENT = createEnvironment();
     public static final String AAS_3_0_RC_02_DATA_SPECIFICATION_IEC_61360 = "https://admin-shell.io/aas/3/0/RC02/DataSpecificationIec61360";
-    private static final String FILE_MASTER_VERWALTUNGSSCHALE_DETAIL_PART1_PNG = "file:///master/verwaltungsschale-detail-part1.png";
-    private static final String IMAGE_PNG = "image/png";
 
     public static AssetAdministrationShell createAAS1() {
         return new DefaultAssetAdministrationShell.Builder()
@@ -119,10 +117,6 @@ public class AASFull {
                         //                .value("http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial")
                         //                .build()))
                         //        .build())
-                        .defaultThumbnail(new DefaultResource.Builder()
-                                .contentType(IMAGE_PNG)
-                                .path(FILE_MASTER_VERWALTUNGSSCHALE_DETAIL_PART1_PNG)
-                                .build())
                         .build())
                 .submodels(new DefaultReference.Builder()
                         .keys(new DefaultKey.Builder()
@@ -1333,7 +1327,7 @@ public class AASFull {
                                                 .build())
                                         .type(ReferenceTypes.EXTERNAL_REFERENCE)
                                         .build())
-                                .value("file:///TestFile2.pdf")
+                                .value("file:///TestFile.pdf")
                                 .contentType("application/pdf")
                                 .build())
                         .value(new DefaultReferenceElement.Builder()

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
@@ -57,6 +57,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProperty;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultQualifier;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultRange;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultResource;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReferenceElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultRelationshipElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
@@ -57,7 +57,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProperty;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultQualifier;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultRange;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReference;
-import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultResource;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultReferenceElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultRelationshipElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/AASFull.java
@@ -87,6 +87,8 @@ public class AASFull {
     public final static ConceptDescription CONCEPT_DESCRIPTION_4 = createConceptDescription4();
     public static final Environment ENVIRONMENT = createEnvironment();
     public static final String AAS_3_0_RC_02_DATA_SPECIFICATION_IEC_61360 = "https://admin-shell.io/aas/3/0/RC02/DataSpecificationIec61360";
+    private static final String FILE_MASTER_VERWALTUNGSSCHALE_DETAIL_PART1_PNG = "file:///master/verwaltungsschale-detail-part1.png";
+    private static final String IMAGE_PNG = "image/png";
 
     public static AssetAdministrationShell createAAS1() {
         return new DefaultAssetAdministrationShell.Builder()
@@ -116,6 +118,10 @@ public class AASFull {
                         //                .value("http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial")
                         //                .build()))
                         //        .build())
+                        .defaultThumbnail(new DefaultResource.Builder()
+                                .contentType(IMAGE_PNG)
+                                .path(FILE_MASTER_VERWALTUNGSSCHALE_DETAIL_PART1_PNG)
+                                .build())
                         .build())
                 .submodels(new DefaultReference.Builder()
                         .keys(new DefaultKey.Builder()
@@ -1326,7 +1332,7 @@ public class AASFull {
                                                 .build())
                                         .type(ReferenceTypes.EXTERNAL_REFERENCE)
                                         .build())
-                                .value("file:///TestFile.pdf")
+                                .value("file:///TestFile2.pdf")
                                 .contentType("application/pdf")
                                 .build())
                         .value(new DefaultReferenceElement.Builder()


### PR DESCRIPTION
When a File had an empty value, a NullpointerException would occur in both AASXDeserializer and AASXSerializer. This is now filtered out with file.getValue != null
Additionally, Files in SubmodelElementLists were not included in the fileList. This was fixed by using the Visitor to get all files.