### PR TITLE
Bugfix/aasx files

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.UUID;
@@ -96,7 +95,6 @@ public class AASXSerializer {
      */
     public void write(Environment environment, Collection<InMemoryFile> files, OutputStream os)
             throws SerializationException, IOException {
-        prepareFilePaths(environment);
 
         OPCPackage rootPackage = OPCPackage.create(os);
 
@@ -248,15 +246,6 @@ public class AASXSerializer {
     }
 
     /**
-     * Replaces the path in all File Elements with the result of preparePath
-     *
-     * @param environment the Environment
-     */
-    private void prepareFilePaths(Environment environment) {
-        findFileElements(environment).forEach(f -> f.setValue(preparePath(f.getValue())));
-    }
-
-    /**
      * Finds an InMemoryFile by its path
      *
      * @param files the InMemoryFiles
@@ -270,19 +259,6 @@ public class AASXSerializer {
             }
         }
         throw new RuntimeException("The wanted file '" + path + "' was not found in the given files.");
-    }
-
-    /**
-     * Removes the serverpart from a path and ensures it starts with "file://"
-     *
-     * @param path the path to be prepared
-     * @return the prepared path
-     */
-    private String preparePath(String path) {
-        if (path.startsWith("/")) {
-            path = "file://" + path;
-        }
-        return path;
     }
 
 }

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.UUID;
 
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
@@ -234,7 +235,7 @@ public class AASXSerializer {
      * @return the found Files
      */
     private Collection<File> findFileElements(Environment environment) {
-        Collection<File> files = new ArrayList<>();
+        Collection<File> files = new HashSet<>();
         new AssetAdministrationShellElementWalkerVisitor() {
             @Override
             public void visit(File file) {

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/ValidationTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/ValidationTest.java
@@ -48,8 +48,11 @@ public class ValidationTest {
     public void validateXmlInsideAasx() throws SerializationException, IOException, InvalidFormatException, DeserializationException, ParserConfigurationException, SAXException {
         List<InMemoryFile> fileList = new ArrayList<>();
         byte[] operationManualContent = { 0, 1, 2, 3, 4 };
+        byte[] thumbnail = { 0, 1, 2, 3, 4 };
         InMemoryFile inMemoryFile = new InMemoryFile(operationManualContent, "file:///aasx/OperatingManual.pdf");
+        InMemoryFile inMemoryFileThumbnail = new InMemoryFile(thumbnail, "file:///master/verwaltungsschale-detail-part1.png");
         fileList.add(inMemoryFile);
+        fileList.add(inMemoryFileThumbnail);
 
         File file = tempFolder.newFile("output.aasx");
 


### PR DESCRIPTION
Closes https://github.com/eclipse-aas4j/aas4j/issues/258

In addition, it fixes an error message that would pop up if a File was referenced multiple times by ensuring files are only included once. The generated AASX in previous versions was fine but the error message was misleading.