### PR TITLE
Fixes example for dependency inclusion in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ or by integrating the respective modules as dependencies from [Maven Central](ht
 ```
 <dependency>
   <groupId>org.eclipse.digitaltwin.aas4j</groupId>
-  <artifactId>aas4j-dataformat-json</artifactId>
-  <version>latest-version</version>
-<dependency>
+  <artifactId>aas4j-model</artifactId>
+  <version>1.0.1</version>
+</dependency>
 ```
 
 ## AAS4J Project Structure


### PR DESCRIPTION
Adds missing forward slash, changes example to model itself, and adds existing latest version.