### PR TITLE
Updates AASX serializations targetMode to EXTERNAL

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXSerializer.java
@@ -251,7 +251,7 @@ public class AASXSerializer {
         }
         writeDataToPart(part, content);
         root.registerPartAndContentType(part);
-        relateTo.addRelationship(partName, TargetMode.INTERNAL, relType, createUniqueID());
+        relateTo.addRelationship(partName, TargetMode.EXTERNAL, relType, createUniqueID());
         return part;
     }
 

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/serialization/AASXSerializerTest.java
@@ -163,6 +163,6 @@ public class AASXSerializerTest {
             throw new RuntimeException(e);
         }
         assertTrue(content.contains("Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/thumbnail\""));
-        assertTrue(content.contains("Target=\"master/verwaltungsschale-detail-part1.png\""));
+        assertTrue(content.contains("Target=\"/master/verwaltungsschale-detail-part1.png\""));
     }
 }


### PR DESCRIPTION
When creating the AASX part, `TargetMode.INTERNAL` was used before. This PR updates it to `EXTERNAL`. 

## Related Issue

Closes #300 