### PR TITLE
Shared external files written to AASX multiple times

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -279,7 +279,7 @@ public class AASXDeserializer {
                 }
             }
         }.visit(environment);
-        return paths.stream().distinct().toList();
+        return paths.stream().distinct().collect(Collectors.toList());
     }
 
 

--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXDeserializer.java
@@ -279,8 +279,9 @@ public class AASXDeserializer {
                 }
             }
         }.visit(environment);
-        return paths;
+        return paths.stream().distinct().toList();
     }
+
 
     private InMemoryFile readFile(OPCPackage aasxRoot, String filePath) throws InvalidFormatException, IOException {
         PackagePart part = aasxRoot.getPart(PackagingURIHelper.createPartName(AASXUtils.removeFilePartOfURI(filePath)));


### PR DESCRIPTION
Fixes a bug that happens when trying to serialize an environment to AASX where external files are references multiple times in either the aas.asset-adminstration.defaultThumbnail or any File element. Those files are now written to the AASX file once.