### PR TITLE
fix: Upgrades the json-schema-validator and adapts breaking changes

### DIFF
--- a/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXValidator.java
+++ b/dataformat-aasx/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/AASXValidator.java
@@ -17,7 +17,9 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.JsonSchemaValidator;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.XmlSchemaValidator;
@@ -43,14 +45,16 @@ public class AASXValidator {
    * @throws IOException failure during filehandling
    * @throws InvalidFormatException specified URI is invalid
    */
-  public List<String> validateSchema() throws IOException, InvalidFormatException {
+  public Set<String> validateSchema() throws IOException, InvalidFormatException {
     String file = deserializer.getResourceString();
-    List<String> errorMessages = null;
+    Set<String> errorMessages = Collections.emptySet();
+
     if (MetamodelContentType.XML.equals(deserializer.getContentType())) {
-      errorMessages = xmlValidator.validateSchema(file);
+      errorMessages = new HashSet<>(xmlValidator.validateSchema(file));
     } else if (MetamodelContentType.JSON.equals(deserializer.getContentType())) {
-      errorMessages = jsonValidator.validateSchema(file);
+      errorMessages = new HashSet<>(jsonValidator.validateSchema(file));
     }
+
     return errorMessages;
   }
 }

--- a/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/ValidationTest.java
+++ b/dataformat-aasx/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/aasx/deserialization/ValidationTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.aasx.AASXSerializer;
@@ -65,7 +66,7 @@ public class ValidationTest {
 
     InputStream in = new FileInputStream(file);
     AASXValidator v = new AASXValidator(in);
-    List<String> validationResult = v.validateSchema();
+    Set<String> validationResult = v.validateSchema();
     System.out.println(validationResult);
     assertEquals(validationResult.size(), 0);
   }

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/SchemaValidator.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/SchemaValidator.java
@@ -15,7 +15,7 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
 
-import java.util.List;
+import java.util.Set;
 
 /** Validator that can validate a serialized AASEnvironment according to a specific schema. */
 public interface SchemaValidator {
@@ -27,5 +27,5 @@ public interface SchemaValidator {
    * @param serializedAASEnvironment A string-serialized AASEnvironment.
    * @return Set of validation errors. If validation succeeds, the Set is empty.
    */
-  List<String> validateSchema(String serializedAASEnvironment);
+  Set<String> validateSchema(String serializedAASEnvironment);
 }

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSchemaValidator.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSchemaValidator.java
@@ -26,7 +26,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SchemaValidator;
 
@@ -48,11 +49,11 @@ public class JsonSchemaValidator implements SchemaValidator {
    * @return Set of messages to display validation results
    */
   @Override
-  public List<String> validateSchema(String serialized) {
+  public Set<String> validateSchema(String serialized) {
     try {
-      return validateSchema(serialized, loadDefaultSchema());
+      return new HashSet<>(validateSchema(serialized, loadDefaultSchema()));
     } catch (IOException | URISyntaxException e) {
-      return List.of(e.getMessage());
+      return Set.of(e.getMessage());
     }
   }
 
@@ -64,17 +65,17 @@ public class JsonSchemaValidator implements SchemaValidator {
    *     aas-schema
    * @return Set of messages to display validation results
    */
-  public List<String> validateSchema(String serialized, String serializedSchema) {
+  public Set<String> validateSchema(String serialized, String serializedSchema) {
     try {
       JsonNode schemaRootNode = mapper.readTree(serializedSchema);
       SchemaRegistry schemaRegistry =
           SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2019_09);
       Schema schema = schemaRegistry.getSchema(schemaRootNode);
       JsonNode node = mapper.readTree(serialized);
-      List<Error> validationMessages = schema.validate(node);
+      Set<Error> validationMessages = new HashSet<>(schema.validate(node));
       return generalizeValidationMessagesAsStringSet(validationMessages);
     } catch (JsonProcessingException e) {
-      return List.of(e.getMessage());
+      return Set.of(e.getMessage());
     }
   }
 
@@ -84,7 +85,7 @@ public class JsonSchemaValidator implements SchemaValidator {
         .collect(Collectors.joining("\n"));
   }
 
-  private List<String> generalizeValidationMessagesAsStringSet(List<Error> messages) {
-    return messages.stream().map(Error::getMessage).collect(Collectors.toList());
+  private Set<String> generalizeValidationMessagesAsStringSet(Set<Error> messages) {
+    return messages.stream().map(Error::getMessage).collect(Collectors.toSet());
   }
 }

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSerializerTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSerializerTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.util.ExampleData;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.util.Examples;
@@ -259,8 +260,8 @@ public class JsonSerializerTest {
   }
 
   private void validateAndCompare(String expected, String actual) {
-    List<String> errors = new JsonSchemaValidator().validateSchema(actual);
-    if (errors.size() > 0) {
+    Set<String> errors = new JsonSchemaValidator().validateSchema(actual);
+    if (!errors.isEmpty()) {
       logger.error(String.join("\n", errors));
     }
     assertTrue(errors.isEmpty());

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonValidationTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonValidationTest.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -42,7 +42,7 @@ public class JsonValidationTest {
   private static final String TEST_FILES_DIR = "target/test-classes/examples";
 
   @BeforeClass
-  public static void prepareValidator() throws IOException {
+  public static void prepareValidator() {
     validator = new JsonSchemaValidator();
   }
 
@@ -86,12 +86,12 @@ public class JsonValidationTest {
   public void validateJsonExamples(String filePath)
       throws DeserializationException, SerializationException, IOException {
     String initialJson = new String(Files.readAllBytes(Paths.get(filePath)));
-    List<String> initialFileValidationError = validateSerializedJson(initialJson);
+    Set<String> initialFileValidationError = validateSerializedJson(initialJson);
 
     Environment environment = new JsonDeserializer().read(initialJson, Environment.class);
     String serializedEnv = new JsonSerializer().write(environment);
 
-    List<String> serializedEnvValidationError = validateSerializedJson(serializedEnv);
+    Set<String> serializedEnvValidationError = validateSerializedJson(serializedEnv);
 
     assumeFalse(
         "Skipping this test because there are same validation errors for the initial file: "
@@ -109,16 +109,16 @@ public class JsonValidationTest {
     assertFalse(validate(file).isEmpty());
   }
 
-  private List<String> validate(String file) throws IOException {
+  private Set<String> validate(String file) throws IOException {
     String json = new String(Files.readAllBytes(Paths.get(file)));
-    List<String> result = validator.validateSchema(json);
+    Set<String> result = validator.validateSchema(json);
     System.out.println("Validating: " + file);
     result.forEach(System.out::println);
     return result;
   }
 
-  private List<String> validateSerializedJson(String serializedEnv) {
-    List<String> result = validator.validateSchema(serializedEnv);
+  private Set<String> validateSerializedJson(String serializedEnv) {
+    Set<String> result = validator.validateSchema(serializedEnv);
     result.forEach(System.out::println);
     return result;
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSchemaValidator.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSchemaValidator.java
@@ -16,8 +16,9 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.io.StringReader;
+import java.util.HashSet;
+import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -39,12 +40,10 @@ public class XmlSchemaValidator implements SchemaValidator {
   }
 
   @Override
-  public List<String> validateSchema(String serializedAASEnvironment) {
-    List<String> errorMessages = new ArrayList<>();
+  public Set<String> validateSchema(String serializedAASEnvironment) {
+    Set<String> errorMessages = new HashSet<>();
     try {
-      schema
-          .newValidator()
-          .validate(new StreamSource(new java.io.StringReader(serializedAASEnvironment)));
+      schema.newValidator().validate(new StreamSource(new StringReader(serializedAASEnvironment)));
     } catch (SAXException | IOException se) {
       errorMessages.add(se.getMessage());
       return errorMessages;

--- a/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSerializerTest.java
+++ b/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSerializerTest.java
@@ -16,14 +16,15 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.AASFull;
@@ -140,7 +141,7 @@ public class XmlSerializerTest {
   public void validateConceptDescriptionAgainstXsdSchema()
       throws SerializationException, SAXException {
     ConceptDescription object = AASSimple.createConceptDescriptionMaxRotationSpeed();
-    List<String> errors =
+    Set<String> errors =
         validateAgainstXsdSchema(
             new XmlSerializer()
                 .write(new DefaultEnvironment.Builder().conceptDescriptions(object).build()));
@@ -170,7 +171,7 @@ public class XmlSerializerTest {
             .build();
     String xml =
         new XmlSerializer().write(new DefaultEnvironment.Builder().submodels(object).build());
-    List<String> errors = validateAgainstXsdSchema(xml);
+    Set<String> errors = validateAgainstXsdSchema(xml);
     assertTrue(errors.isEmpty());
   }
 
@@ -187,7 +188,7 @@ public class XmlSerializerTest {
             .build();
     String xml =
         new XmlSerializer().write(new DefaultEnvironment.Builder().submodels(submodel).build());
-    List<String> errors = validateAgainstXsdSchema(xml);
+    Set<String> errors = validateAgainstXsdSchema(xml);
     assertTrue(errors.isEmpty());
   }
 
@@ -197,7 +198,7 @@ public class XmlSerializerTest {
     Submodel object = AASSimple.createSubmodelDocumentation();
     String xml =
         new XmlSerializer().write(new DefaultEnvironment.Builder().submodels(object).build());
-    List<String> errors = validateAgainstXsdSchema(xml);
+    Set<String> errors = validateAgainstXsdSchema(xml);
     assertTrue(errors.isEmpty());
   }
 
@@ -207,7 +208,7 @@ public class XmlSerializerTest {
     String xml =
         new XmlSerializer()
             .write(new DefaultEnvironment.Builder().conceptDescriptions(object).build());
-    List<String> errors = validateAgainstXsdSchema(xml);
+    Set<String> errors = validateAgainstXsdSchema(xml);
     assertTrue(errors.isEmpty());
   }
 
@@ -323,7 +324,7 @@ public class XmlSerializerTest {
     assertEquals(expected, actual);
   }
 
-  private List<String> validateAgainstXsdSchema(String xml) throws SAXException {
+  private Set<String> validateAgainstXsdSchema(String xml) throws SAXException {
     return new XmlSchemaValidator().validateSchema(xml);
   }
 
@@ -336,7 +337,7 @@ public class XmlSerializerTest {
       File expectedFile, Environment environment, XmlSerializer xmlSerializer)
       throws SerializationException, SAXException {
     String actual = xmlSerializer.write(environment);
-    List<String> errors = validateAgainstXsdSchema(actual);
+    Set<String> errors = validateAgainstXsdSchema(actual);
     logErrors(expectedFile.getName(), errors);
     assertTrue(errors.isEmpty());
     CompareMatcher xmlTestMatcher =
@@ -394,7 +395,7 @@ public class XmlSerializerTest {
     return true;
   }
 
-  private void logErrors(String validatedFileName, List<String> errors) {
+  private void logErrors(String validatedFileName, Set<String> errors) {
     if (errors.isEmpty()) {
       return;
     }

--- a/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlValidationTest.java
+++ b/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlValidationTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -80,7 +81,7 @@ public class XmlValidationTest {
   // import from admin-shell.io -> is actually V3
   // -> fix name, as soon as it is fixed externally
   public void validateValidXml(String file) throws IOException {
-    List<String> errors = validateXmlFile(file);
+    Set<String> errors = validateXmlFile(file);
     logErrors(file, errors);
     assertTrue(errors.isEmpty());
   }
@@ -91,7 +92,7 @@ public class XmlValidationTest {
     "src/test/resources/ServoDCMotor_invalid.xml"
   })
   public void validateInvalidXml(String file) throws IOException {
-    List<String> errors = validateXmlFile(file);
+    Set<String> errors = validateXmlFile(file);
     logErrors(file, errors);
     assertEquals(1, errors.size());
   }
@@ -116,13 +117,13 @@ public class XmlValidationTest {
     Environment environment = new XmlDeserializer().read(initialXml);
     String serializedEnv = new XmlSerializer().write(environment);
 
-    List<String> serializedEnvValidationError = validateSerializedXmlFile(serializedEnv);
+    Set<String> serializedEnvValidationError = validateSerializedXmlFile(serializedEnv);
     logErrors(filePath, serializedEnvValidationError);
 
     assertTrue(serializedEnvValidationError.isEmpty());
   }
 
-  private void logErrors(String validatedFileName, List<String> errors) {
+  private void logErrors(String validatedFileName, Set<String> errors) {
     if (errors.isEmpty()) {
       return;
     }
@@ -132,12 +133,12 @@ public class XmlValidationTest {
     }
   }
 
-  private List<String> validateXmlFile(String file) throws IOException {
+  private Set<String> validateXmlFile(String file) throws IOException {
     String serializedEnvironment = new String(Files.readAllBytes(Paths.get(file)));
     return validator.validateSchema(serializedEnvironment);
   }
 
-  private List<String> validateSerializedXmlFile(String serializedXml) {
+  private Set<String> validateSerializedXmlFile(String serializedXml) {
     return validator.validateSchema(serializedXml);
   }
 


### PR DESCRIPTION
Bumps the `json-schema-validator `to `2.0.0` and adapts the breaking changes.
Followed below migration guideline:
[Migration to 2.0.0 from 1.5.x](https://github.com/networknt/json-schema-validator/blob/master/doc/migration-2.0.0.md)

Supersedes: #435 