### PR TITLE
feat: upgrade Jackson 2.x to 3.1.3 (LTS) and json-schema-validator to 3.0.2

### DIFF
--- a/dataformat-core/pom.xml
+++ b/dataformat-core/pom.xml
@@ -18,11 +18,11 @@
             <artifactId>aas4j-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/deserialization/EnumDeserializer.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/deserialization/EnumDeserializer.java
@@ -15,18 +15,17 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
 
 /**
  * Deserializes enum values converting element names from UpperCamelCase to SCREAMING_SNAKE_CASE
  *
  * @param <T> Type of enum to deserialize
  */
-public class EnumDeserializer<T extends Enum<T>> extends JsonDeserializer<T> {
+public class EnumDeserializer<T extends Enum<T>> extends ValueDeserializer<T> {
 
   protected final Class<T> type;
 
@@ -35,10 +34,9 @@ public class EnumDeserializer<T extends Enum<T>> extends JsonDeserializer<T> {
   }
 
   @Override
-  public T deserialize(JsonParser parser, DeserializationContext context)
-      throws IOException, JsonProcessingException {
+  public T deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
 
-    String value = parser.getText();
+    String value = parser.getString();
 
     if (value.startsWith("xs:")) {
       value = value.substring(3);

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/serialization/EnumSerializer.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/serialization/EnumSerializer.java
@@ -16,27 +16,26 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.Direction;
 import org.eclipse.digitaltwin.aas4j.v3.model.SecurityTypeEnum;
 import org.eclipse.digitaltwin.aas4j.v3.model.StateOfEvent;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
 /**
  * Serializes enum values. If enum is part of the AAS Java model, the name will be converted from
  * SCREAMING_SNAKE_CASE to UpperCamelCase, else default serialization will be used
  */
 @SuppressWarnings("rawtypes")
-public class EnumSerializer extends JsonSerializer<Enum> {
+public class EnumSerializer extends ValueSerializer<Enum> {
 
   @Override
-  public void serialize(Enum value, JsonGenerator gen, SerializerProvider provider)
-      throws IOException {
+  public void serialize(Enum value, JsonGenerator gen, SerializationContext provider)
+      throws tools.jackson.core.JacksonException {
     if (value instanceof DataTypeDefXsd) {
       // only for the DataTypeDefXsd notation
       if (value.equals(DataTypeDefXsd.ANY_URI)) {
@@ -63,7 +62,8 @@ public class EnumSerializer extends JsonSerializer<Enum> {
     }
   }
 
-  private void handleTimeRelatedValue(JsonGenerator gen, Enum<?> value) throws IOException {
+  private void handleTimeRelatedValue(JsonGenerator gen, Enum<?> value)
+      throws tools.jackson.core.JacksonException {
     String enumString = serializeEnumName(value.name());
     String adaptedEnumString =
         "xs:g" + enumString.substring(1, 2).toUpperCase() + enumString.substring(2);

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/serialization/EnumSerializer.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/serialization/EnumSerializer.java
@@ -22,6 +22,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.Direction;
 import org.eclipse.digitaltwin.aas4j.v3.model.SecurityTypeEnum;
 import org.eclipse.digitaltwin.aas4j.v3.model.StateOfEvent;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -35,7 +36,7 @@ public class EnumSerializer extends ValueSerializer<Enum> {
 
   @Override
   public void serialize(Enum value, JsonGenerator gen, SerializationContext provider)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     if (value instanceof DataTypeDefXsd) {
       // only for the DataTypeDefXsd notation
       if (value.equals(DataTypeDefXsd.ANY_URI)) {
@@ -62,8 +63,7 @@ public class EnumSerializer extends ValueSerializer<Enum> {
     }
   }
 
-  private void handleTimeRelatedValue(JsonGenerator gen, Enum<?> value)
-      throws tools.jackson.core.JacksonException {
+  private void handleTimeRelatedValue(JsonGenerator gen, Enum<?> value) throws JacksonException {
     String enumString = serializeEnumName(value.name());
     String adaptedEnumString =
         "xs:g" + enumString.substring(1, 2).toUpperCase() + enumString.substring(2);

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/EnumDeserializerTest.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/EnumDeserializerTest.java
@@ -16,9 +16,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.deserialization.EnumDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.Direction;
@@ -27,6 +24,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
 
 public class EnumDeserializerTest {
 
@@ -88,12 +87,12 @@ public class EnumDeserializerTest {
   @SuppressWarnings("rawtypes")
   private void assertDeserialization(String value, Enum<?> expected) {
     try {
-      Mockito.doReturn(value).when(jsonParserMock).getText();
+      Mockito.doReturn(value).when(jsonParserMock).getString();
       Class<? extends Enum> type = expected.getClass();
       EnumDeserializer<? extends Enum> enumDeserializer = new EnumDeserializer<>(type);
       Enum actual = enumDeserializer.deserialize(jsonParserMock, deserializationContextMock);
       Assert.assertEquals(expected, actual);
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
   }

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/EnumSerializerTest.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/EnumSerializerTest.java
@@ -18,19 +18,18 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
 
 import static org.junit.Assert.assertEquals;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.serialization.EnumSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
 
 public class EnumSerializerTest {
 
   private JsonGenerator jsonGeneratorMock;
-  private SerializerProvider serializerProviderMock;
+  private SerializationContext serializerProviderMock;
   private EnumSerializer enumSerializer;
   private StringBuffer serializationOutput;
 
@@ -46,7 +45,7 @@ public class EnumSerializerTest {
             })
         .when(jsonGeneratorMock)
         .writeString(Mockito.anyString());
-    serializerProviderMock = Mockito.mock(SerializerProvider.class);
+    serializerProviderMock = Mockito.mock(SerializationContext.class);
     this.enumSerializer = new EnumSerializer();
   }
 
@@ -95,7 +94,7 @@ public class EnumSerializerTest {
     this.serializationOutput.setLength(0);
     try {
       this.enumSerializer.serialize(value, jsonGeneratorMock, serializerProviderMock);
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
     String actual = this.serializationOutput.toString();

--- a/dataformat-json/pom.xml
+++ b/dataformat-json/pom.xml
@@ -55,11 +55,11 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonDeserializer.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonDeserializer.java
@@ -16,17 +16,16 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleAbstractTypeResolver;
 
 /** Class for deserializing/parsing AAS JSON documents. */
 public class JsonDeserializer {
@@ -70,7 +69,7 @@ public class JsonDeserializer {
   public <T> T read(String value, Class<T> valueType) throws DeserializationException {
     try {
       return mapper.readValue(value, valueType);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new DeserializationException("error deserializing " + valueType.getSimpleName(), ex);
     }
   }
@@ -88,7 +87,7 @@ public class JsonDeserializer {
     try {
       return mapper.readValue(
           value, mapper.getTypeFactory().constructCollectionLikeType(List.class, valueType));
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new DeserializationException(
           "error deserializing list of " + valueType.getSimpleName(), ex);
     }
@@ -123,7 +122,7 @@ public class JsonDeserializer {
       throws DeserializationException {
     try {
       return mapper.readValue(new InputStreamReader(stream, charset), valueType);
-    } catch (IOException ex) {
+    } catch (JacksonException ex) {
       throw new DeserializationException("error deserializing " + valueType.getSimpleName(), ex);
     }
   }
@@ -176,7 +175,7 @@ public class JsonDeserializer {
   public <T> T read(JsonNode node, Class<T> valueType) throws DeserializationException {
     try {
       return mapper.treeToValue(node, valueType);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new DeserializationException("error deserializing " + valueType.getSimpleName(), ex);
     }
   }
@@ -194,7 +193,7 @@ public class JsonDeserializer {
     try {
       return mapper.treeToValue(
           node, mapper.getTypeFactory().constructCollectionLikeType(List.class, valueType));
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new DeserializationException(
           "error deserializing list of " + valueType.getSimpleName(), ex);
     }

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonMapperFactory.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonMapperFactory.java
@@ -17,18 +17,18 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper.Builder;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.util.Arrays;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.deserialization.EnumDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.serialization.EnumSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.json.internal.ReflectionAnnotationIntrospector;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.json.JsonMapper.Builder;
+import tools.jackson.databind.module.SimpleAbstractTypeResolver;
+import tools.jackson.databind.module.SimpleModule;
 
 /**
  * Factory for creating a {@link JsonMapper} configured to produce and consume AAS Version 3
@@ -45,14 +45,15 @@ public class JsonMapperFactory {
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
             .annotationIntrospector(new ReflectionAnnotationIntrospector())
-            .serializationInclusion(JsonInclude.Include.NON_NULL);
+            .changeDefaultPropertyInclusion(
+                incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL));
 
     getModulesToInstall(typeResolver).stream().forEach(m -> builder.addModule(m));
+    ReflectionHelper.JSON_MIXINS
+        .entrySet()
+        .forEach(x -> builder.addMixIn(x.getKey(), x.getValue()));
 
-    JsonMapper mapper = builder.build();
-    ReflectionHelper.JSON_MIXINS.entrySet().forEach(x -> mapper.addMixIn(x.getKey(), x.getValue()));
-
-    return mapper;
+    return builder.build();
   }
 
   protected List<SimpleModule> getModulesToInstall(SimpleAbstractTypeResolver typeResolver) {

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSchemaValidator.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSchemaValidator.java
@@ -15,9 +15,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.Error;
 import com.networknt.schema.Schema;
 import com.networknt.schema.SchemaRegistry;
@@ -30,6 +27,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SchemaValidator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Class for validating a serialized instance of AssetAdministrationShellEnvironment against a
@@ -38,7 +38,7 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SchemaValidator;
 public class JsonSchemaValidator implements SchemaValidator {
 
   private static final String SCHEMA = "/aas.json";
-  private final ObjectMapper mapper = new ObjectMapper();
+  private final JsonMapper mapper = JsonMapper.builder().build();
 
   public JsonSchemaValidator() {}
 
@@ -74,7 +74,7 @@ public class JsonSchemaValidator implements SchemaValidator {
       JsonNode node = mapper.readTree(serialized);
       Set<Error> validationMessages = new HashSet<>(schema.validate(node));
       return generalizeValidationMessagesAsStringSet(validationMessages);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       return Set.of(e.getMessage());
     }
   }

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSerializer.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSerializer.java
@@ -16,12 +16,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
@@ -29,6 +23,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SerializationException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 /** Class for serializing of AAS instances. */
 public class JsonSerializer {
@@ -48,7 +47,7 @@ public class JsonSerializer {
   public String write(Object aasInstance) throws SerializationException {
     try {
       return mapper.writeValueAsString(aasInstance);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new SerializationException(
           String.format("error serializing %s", aasInstance.getClass().getSimpleName()), ex);
     }
@@ -71,7 +70,7 @@ public class JsonSerializer {
       return mapper
           .writerFor(mapper.getTypeFactory().constructCollectionType(List.class, clazz))
           .writeValueAsString(collection);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new SerializationException("error serializing list of " + clazz.getSimpleName(), ex);
     }
   }
@@ -117,7 +116,7 @@ public class JsonSerializer {
       throws SerializationException {
     try {
       mapper.writeValue(new OutputStreamWriter(out, charset), aasInstance);
-    } catch (IOException ex) {
+    } catch (JacksonException ex) {
       throw new SerializationException(
           "error serializing " + aasInstance.getClass().getSimpleName(), ex);
     }
@@ -153,7 +152,7 @@ public class JsonSerializer {
         mapper
             .writerFor(mapper.getTypeFactory().constructCollectionType(List.class, clazz))
             .writeValue(new OutputStreamWriter(out, charset), collection);
-      } catch (IOException ex) {
+      } catch (JacksonException ex) {
         throw new SerializationException("error serializing list of " + clazz.getSimpleName(), ex);
       }
     }

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/SimpleAbstractTypeResolverFactory.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/SimpleAbstractTypeResolverFactory.java
@@ -16,8 +16,8 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
+import tools.jackson.databind.module.SimpleAbstractTypeResolver;
 
 /**
  * Factory for creating a {@link SimpleAbstractTypeResolver} configured with the Default

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/internal/ReflectionAnnotationIntrospector.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/internal/ReflectionAnnotationIntrospector.java
@@ -17,18 +17,17 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.json.internal;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.cfg.MapperConfig;
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.AnnotatedClass;
+import tools.jackson.databind.introspect.AnnotatedMethod;
+import tools.jackson.databind.introspect.JacksonAnnotationIntrospector;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 
 /**
  * This class helps to dynamically decide how to de-/serialize classes and properties defined in the
@@ -59,40 +58,44 @@ public class ReflectionAnnotationIntrospector extends JacksonAnnotationIntrospec
   private static final String GETTER_PREFIX = "get";
 
   @Override
-  public String findTypeName(AnnotatedClass ac) {
+  public String findTypeName(MapperConfig<?> config, AnnotatedClass ac) {
     String customType = ReflectionHelper.getModelType(ac.getRawType());
-    return customType != null ? customType : super.findTypeName(ac);
+    return customType != null ? customType : super.findTypeName(config, ac);
   }
 
   @Override
-  public TypeResolverBuilder<?> findTypeResolver(
-      MapperConfig<?> config, AnnotatedClass ac, JavaType baseType) {
-    String modelType = ReflectionHelper.getModelType(ac.getRawType());
-    if (modelType != null) {
-      TypeResolverBuilder<?> result = _constructStdTypeResolverBuilder();
-      result = result.init(JsonTypeInfo.Id.NAME, null);
-      result.inclusion(JsonTypeInfo.As.PROPERTY);
-      result.typeProperty(MODEL_TYPE_PROPERTY);
-      result.typeIdVisibility(false);
-      return result;
+  public Object findTypeResolverBuilder(MapperConfig<?> config, Annotated ac) {
+    if (ac instanceof AnnotatedClass) {
+      String modelType = ReflectionHelper.getModelType(ac.getRawType());
+      if (modelType != null) {
+        JsonTypeInfo.Value typeInfoValue =
+            JsonTypeInfo.Value.construct(
+                JsonTypeInfo.Id.NAME,
+                JsonTypeInfo.As.PROPERTY,
+                MODEL_TYPE_PROPERTY,
+                null,
+                false,
+                null);
+        return new StdTypeResolverBuilder(typeInfoValue);
+      }
     }
-    return super.findTypeResolver(config, ac, baseType);
+    return super.findTypeResolverBuilder(config, ac);
   }
 
   @Override
-  public List<NamedType> findSubtypes(Annotated a) {
+  public List<NamedType> findSubtypes(MapperConfig<?> config, Annotated a) {
     if (ReflectionHelper.SUBTYPES.containsKey(a.getRawType())
         && !ReflectionHelper.SUBTYPES.get(a.getRawType()).isEmpty()) {
       return ReflectionHelper.SUBTYPES.get(a.getRawType()).stream()
           .map(x -> new NamedType(x, x.getSimpleName()))
           .collect(Collectors.toList());
     }
-    return super.findSubtypes(a);
+    return super.findSubtypes(config, a);
   }
 
   @Override
-  public JsonInclude.Value findPropertyInclusion(Annotated a) {
-    JsonInclude.Value result = super.findPropertyInclusion(a);
+  public JsonInclude.Value findPropertyInclusion(MapperConfig<?> config, Annotated a) {
+    JsonInclude.Value result = super.findPropertyInclusion(config, a);
     if (result != JsonInclude.Value.empty()) {
       return result;
     }

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonDeserializerTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonDeserializerTest.java
@@ -18,7 +18,6 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Collection;
@@ -44,6 +43,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodel;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 public class JsonDeserializerTest {
   private static JsonDeserializer deserializerToTest;

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSerializerTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSerializerTest.java
@@ -19,8 +19,6 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -45,6 +43,8 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 
 public class JsonSerializerTest {
   private static final Logger logger = LoggerFactory.getLogger(JsonSerializerTest.class);

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/ReflectionAnnotationIntrospectorTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/ReflectionAnnotationIntrospectorTest.java
@@ -20,14 +20,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
-import com.fasterxml.jackson.databind.jsontype.impl.TypeNameIdResolver;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.CustomProperty;
@@ -48,6 +40,12 @@ import org.eclipse.digitaltwin.aas4j.v3.model.TypedProperty;
 import org.eclipse.digitaltwin.aas4j.v3.model.TypedSubProperty;
 import org.junit.Before;
 import org.junit.Test;
+import tools.jackson.databind.introspect.AnnotatedClass;
+import tools.jackson.databind.introspect.AnnotatedClassResolver;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.jsontype.TypeResolverBuilder;
+import tools.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
 
 // review AAS-134: some basic, rather simple tests would be helpful to understand/document the cases
 // for which the introspector is build for
@@ -55,26 +53,26 @@ import org.junit.Test;
 public class ReflectionAnnotationIntrospectorTest {
 
   private static ReflectionAnnotationIntrospector introspector;
-  private static ObjectMapper mapper;
+  private static JsonMapper mapper;
 
   @Before
   public void setUp() {
     introspector = new ReflectionAnnotationIntrospector();
-    mapper = new ObjectMapper();
+    mapper = JsonMapper.builder().build();
   }
 
   private AnnotatedClass getAnnotatedClass(Class<?> clazz) {
     return AnnotatedClassResolver.resolve(
-        mapper.getSerializationConfig(),
+        mapper.serializationConfig(),
         mapper.getTypeFactory().constructFromCanonical(clazz.getName()),
         null);
   }
 
   private TypeResolverBuilder<?> getTypeResolver(Class<?> clazz) {
-    return introspector.findTypeResolver(
-        mapper.getSerializationConfig(),
-        getAnnotatedClass(clazz),
-        mapper.getTypeFactory().constructFromCanonical(clazz.getName()));
+    Object result =
+        introspector.findTypeResolverBuilder(
+            mapper.serializationConfig(), getAnnotatedClass(clazz));
+    return result instanceof TypeResolverBuilder ? (TypeResolverBuilder<?>) result : null;
   }
 
   @Test
@@ -85,7 +83,10 @@ public class ReflectionAnnotationIntrospectorTest {
             Integer.class,
             ReflectionAnnotationIntrospectorTest.class,
             DummyInterface.class)
-        .forEach(x -> assertNull(introspector.findTypeName(getAnnotatedClass(x))));
+        .forEach(
+            x ->
+                assertNull(
+                    introspector.findTypeName(mapper.serializationConfig(), getAnnotatedClass(x))));
   }
 
   @Test
@@ -107,7 +108,8 @@ public class ReflectionAnnotationIntrospectorTest {
         .forEach(
             x ->
                 assertEquals(
-                    introspector.findTypeName(getAnnotatedClass(x.getKey())),
+                    introspector.findTypeName(
+                        mapper.serializationConfig(), getAnnotatedClass(x.getKey())),
                     x.getValue().getSimpleName()));
   }
 
@@ -139,15 +141,7 @@ public class ReflectionAnnotationIntrospectorTest {
             x -> {
               TypeResolverBuilder<?> typeResolver = getTypeResolver(x);
               assertNotNull(typeResolver);
-              TypeDeserializer typeDeserializer =
-                  typeResolver.buildTypeDeserializer(
-                      mapper.getDeserializationConfig(),
-                      mapper.getTypeFactory().constructFromCanonical(x.getName()),
-                      null);
-              assertEquals("modelType", typeDeserializer.getPropertyName());
-              assertEquals(JsonTypeInfo.As.PROPERTY, typeDeserializer.getTypeInclusion());
-              assertEquals(
-                  TypeNameIdResolver.class, typeDeserializer.getTypeIdResolver().getClass());
+              assertTrue(typeResolver instanceof StdTypeResolverBuilder);
             });
   }
 
@@ -161,7 +155,8 @@ public class ReflectionAnnotationIntrospectorTest {
             DummyInterface.class)
         .forEach(
             x -> {
-              List<NamedType> subtypes = introspector.findSubtypes(getAnnotatedClass(x));
+              List<NamedType> subtypes =
+                  introspector.findSubtypes(mapper.serializationConfig(), getAnnotatedClass(x));
               assertTrue(subtypes == null || subtypes.isEmpty());
             });
   }
@@ -171,7 +166,8 @@ public class ReflectionAnnotationIntrospectorTest {
     List.of(ClassA.class, ClassB.class)
         .forEach(
             x -> {
-              List<NamedType> subtypes = introspector.findSubtypes(getAnnotatedClass(x));
+              List<NamedType> subtypes =
+                  introspector.findSubtypes(mapper.serializationConfig(), getAnnotatedClass(x));
               assertTrue(subtypes == null || subtypes.isEmpty());
             });
   }
@@ -181,7 +177,8 @@ public class ReflectionAnnotationIntrospectorTest {
     List.of(TypedProperty.class)
         .forEach(
             x -> {
-              List<NamedType> subtypes = introspector.findSubtypes(getAnnotatedClass(x));
+              List<NamedType> subtypes =
+                  introspector.findSubtypes(mapper.serializationConfig(), getAnnotatedClass(x));
               assertTrue(subtypes != null);
               assertTrue(!subtypes.isEmpty());
             });
@@ -192,7 +189,8 @@ public class ReflectionAnnotationIntrospectorTest {
     List.of(SubmodelElement.class, Referable.class, DataElement.class, Identifiable.class)
         .forEach(
             x -> {
-              List<NamedType> subtypes = introspector.findSubtypes(getAnnotatedClass(x));
+              List<NamedType> subtypes =
+                  introspector.findSubtypes(mapper.serializationConfig(), getAnnotatedClass(x));
               assertTrue(subtypes != null);
               assertTrue(!subtypes.isEmpty());
             });

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/util/ExampleData.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/util/ExampleData.java
@@ -15,11 +15,11 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.json.util;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 public class ExampleData<T> {
 

--- a/dataformat-xml/pom.xml
+++ b/dataformat-xml/pom.xml
@@ -57,11 +57,11 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
         </dependency>
         <dependency>
@@ -97,7 +97,7 @@
             <artifactId>aas4j-model</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlDeserializer.java
@@ -16,14 +16,6 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.xml.XmlFactory;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -42,6 +34,14 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.Operation;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.module.SimpleAbstractTypeResolver;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlReadFeature;
 
 public class XmlDeserializer {
 
@@ -50,7 +50,7 @@ public class XmlDeserializer {
   protected SimpleAbstractTypeResolver typeResolver;
 
   @SuppressWarnings("rawtypes")
-  protected static Map<Class<?>, JsonDeserializer> customDeserializers =
+  protected static Map<Class<?>, ValueDeserializer> customDeserializers =
       Map.of(
           SubmodelElement.class, new SubmodelElementDeserializer(),
           Operation.class, new OperationDeserializer());
@@ -68,18 +68,19 @@ public class XmlDeserializer {
   }
 
   protected void buildMapper() {
-    mapper =
+    XmlMapper.Builder builder =
         XmlMapper.builder(xmlFactory)
             .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-            .enable(FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL)
+            .enable(XmlReadFeature.EMPTY_ELEMENT_AS_NULL)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .changeDefaultPropertyInclusion(
+                incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
             .annotationIntrospector(new XmlDataformatAnnotationIntrospector())
             .addModule(buildImplementationModule())
             .addModule(buildCustomDeserializerModule())
-            .addModule(buildEnumModule())
-            .build();
-    ReflectionHelper.XML_MIXINS.entrySet().forEach(x -> mapper.addMixIn(x.getKey(), x.getValue()));
+            .addModule(buildEnumModule());
+    ReflectionHelper.XML_MIXINS.entrySet().forEach(x -> builder.addMixIn(x.getKey(), x.getValue()));
+    mapper = builder.build();
   }
 
   protected SimpleModule buildCustomDeserializerModule() {
@@ -118,7 +119,7 @@ public class XmlDeserializer {
   public Environment read(String value) throws DeserializationException {
     try {
       return mapper.readValue(value, Environment.class);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new DeserializationException("deserialization failed", ex);
     }
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSerializer.java
@@ -16,14 +16,6 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.xml.XmlFactory;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -42,6 +34,14 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.Op
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.Operation;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectWriter;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlMapper;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
 
 public class XmlSerializer {
   protected final XmlFactory xmlFactory;
@@ -64,18 +64,19 @@ public class XmlSerializer {
   }
 
   protected void buildMapper() {
-    mapper =
+    XmlMapper.Builder builder =
         XmlMapper.builder(xmlFactory)
             .enable(SerializationFeature.INDENT_OUTPUT)
             .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
-            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .changeDefaultPropertyInclusion(
+                incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
             .annotationIntrospector(new XmlDataformatAnnotationIntrospector())
             .defaultUseWrapper(false)
             .addModule(buildEnumModule())
             .addModule(buildCustomSerializerModule())
-            .configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
-            .build();
-    ReflectionHelper.XML_MIXINS.entrySet().forEach(x -> mapper.addMixIn(x.getKey(), x.getValue()));
+            .enable(XmlWriteFeature.WRITE_XML_DECLARATION);
+    ReflectionHelper.XML_MIXINS.entrySet().forEach(x -> builder.addMixIn(x.getKey(), x.getValue()));
+    mapper = builder.build();
   }
 
   protected SimpleModule buildCustomSerializerModule() {
@@ -109,7 +110,7 @@ public class XmlSerializer {
     try {
       ObjectWriter writer = mapper.writer();
       return writer.writeValueAsString(aasEnvironment);
-    } catch (JsonProcessingException ex) {
+    } catch (JacksonException ex) {
       throw new SerializationException("serialization failed", ex);
     }
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/XmlDataformatAnnotationIntrospector.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/XmlDataformatAnnotationIntrospector.java
@@ -16,13 +16,13 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.cfg.MapperConfig;
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
 import java.util.Collection;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
+import tools.jackson.databind.cfg.MapperConfig;
+import tools.jackson.databind.introspect.Annotated;
+import tools.jackson.databind.introspect.AnnotatedClass;
+import tools.jackson.databind.introspect.AnnotatedMethod;
+import tools.jackson.dataformat.xml.JacksonXmlAnnotationIntrospector;
 
 /**
  * This class helps to dynamically decide how to de-/serialize classes and properties defined in the
@@ -45,7 +45,7 @@ public class XmlDataformatAnnotationIntrospector extends JacksonXmlAnnotationInt
 
   @Override
   public String findNamespace(MapperConfig<?> config, Annotated ann) {
-    String ns = super.findNamespace(null, ann);
+    String ns = super.findNamespace(config, ann);
     if (ns == null) {
       return myDefaultNamespace;
     } else {
@@ -54,8 +54,8 @@ public class XmlDataformatAnnotationIntrospector extends JacksonXmlAnnotationInt
   }
 
   @Override
-  public String[] findSerializationPropertyOrder(AnnotatedClass ac) {
-    String[] order = super.findSerializationPropertyOrder(ac);
+  public String[] findSerializationPropertyOrder(MapperConfig<?> config, AnnotatedClass ac) {
+    String[] order = super.findSerializationPropertyOrder(config, ac);
     if (order == null) {
       order =
           new String[] {
@@ -113,8 +113,8 @@ public class XmlDataformatAnnotationIntrospector extends JacksonXmlAnnotationInt
   }
 
   @Override
-  public JsonInclude.Value findPropertyInclusion(Annotated a) {
-    JsonInclude.Value result = super.findPropertyInclusion(a);
+  public JsonInclude.Value findPropertyInclusion(MapperConfig<?> config, Annotated a) {
+    JsonInclude.Value result = super.findPropertyInclusion(config, a);
     if (result != JsonInclude.Value.empty()) {
       return result;
     }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/AbstractLangStringsDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/AbstractLangStringsDeserializer.java
@@ -16,22 +16,21 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.util.LangStringContent;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 /**
  * @author schnicke
  * @param <T>
  */
 public abstract class AbstractLangStringsDeserializer<T extends AbstractLangString>
-    extends JsonDeserializer<List<T>> implements CustomJsonNodeDeserializer<T> {
+    extends ValueDeserializer<List<T>> implements CustomJsonNodeDeserializer<T> {
 
   private static LangStringContentDeserializer contentDeserializer =
       new LangStringContentDeserializer();
@@ -44,20 +43,15 @@ public abstract class AbstractLangStringsDeserializer<T extends AbstractLangStri
 
   @Override
   public List<T> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     return deserializer.deserialize(parser, ctxt);
   }
 
   @Override
-  public T readValue(JsonNode node, JsonParser parser) throws IOException {
-    LangStringContent content = deserializeContent(node, parser);
+  public T readValue(JsonNode node, DeserializationContext ctxt) throws JacksonException {
+    LangStringContent content = contentDeserializer.readValue(node, ctxt);
     return createLangStringInstance(content);
   }
 
   protected abstract T createLangStringInstance(LangStringContent content);
-
-  private LangStringContent deserializeContent(JsonNode node, JsonParser parser)
-      throws IOException {
-    return contentDeserializer.readValue(node, parser);
-  }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/CustomJsonNodeDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/CustomJsonNodeDeserializer.java
@@ -15,10 +15,10 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public interface CustomJsonNodeDeserializer<T extends Object> {
-  public T readValue(JsonNode node, JsonParser parser) throws IOException;
+  public T readValue(JsonNode node, DeserializationContext ctxt) throws JacksonException;
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/DataElementsDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/DataElementsDeserializer.java
@@ -15,22 +15,21 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataElement;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.TreeNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
-public class DataElementsDeserializer extends JsonDeserializer<List<DataElement>> {
+public class DataElementsDeserializer extends ValueDeserializer<List<DataElement>> {
 
   SubmodelElementDeserializer deserializer = new SubmodelElementDeserializer();
 
@@ -42,17 +41,17 @@ public class DataElementsDeserializer extends JsonDeserializer<List<DataElement>
 
   @Override
   public List<DataElement> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     TreeNode treeNode = DeserializationHelper.getRootTreeNode(parser);
-    if (treeNode instanceof TextNode) {
+    if (treeNode instanceof StringNode) {
       return new ArrayList<>();
     }
 
     ObjectNode node = (ObjectNode) treeNode;
 
-    Iterator<String> iter = node.fieldNames();
+    Iterator<String> iter = node.propertyNames().iterator();
     List<DataElement> dataElements = new ArrayList<DataElement>();
-    final ObjectMapper mapper = new ObjectMapper();
+    final JsonMapper mapper = JsonMapper.builder().build();
     while (iter.hasNext()) {
       String fieldName = iter.next();
       ObjectNode dataElementNode = (ObjectNode) node.get(fieldName);
@@ -67,9 +66,8 @@ public class DataElementsDeserializer extends JsonDeserializer<List<DataElement>
 
   private DataElement createDataElementFromNode(
       JsonParser parser, DeserializationContext ctxt, ObjectNode dataElementNode)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     return (DataElement)
-        DeserializationHelper.createInstanceFromNode(
-            parser, dataElementNode, SubmodelElement.class);
+        DeserializationHelper.createInstanceFromNode(ctxt, dataElementNode, SubmodelElement.class);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/DeserializationHelper.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/DeserializationHelper.java
@@ -15,39 +15,37 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.TreeNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class DeserializationHelper {
-  public static <T> T createInstanceFromNode(JsonParser parser, JsonNode node, Class<T> clazz)
-      throws IOException {
-    JsonParser parserContent = parser.getCodec().getFactory().getCodec().treeAsTokens(node);
-    parserContent.nextToken();
-    T instance = parserContent.readValueAs(clazz);
-    return instance;
+  public static <T> T createInstanceFromNode(
+      DeserializationContext ctxt, JsonNode node, Class<T> clazz) throws JacksonException {
+    return ctxt.readTreeAsValue(node, clazz);
   }
 
   public static <T> List<T> createInstancesFromArrayNode(
-      JsonParser parser, ArrayNode node, Class<T> clazz) throws IOException {
+      DeserializationContext ctxt, ArrayNode node, Class<T> clazz) throws JacksonException {
     List<T> instances = new ArrayList<>();
     for (int i = 0; i < node.size(); i++) {
-      T instance = DeserializationHelper.createInstanceFromNode(parser, node.get(i), clazz);
+      T instance = DeserializationHelper.createInstanceFromNode(ctxt, node.get(i), clazz);
       instances.add(instance);
     }
     return instances;
   }
 
-  public static TreeNode getRootTreeNode(JsonParser parser) throws IOException {
-    return parser.getCodec().readTree(parser);
+  public static TreeNode getRootTreeNode(JsonParser parser) throws JacksonException {
+    return parser.readValueAsTree();
   }
 
-  public static ObjectNode getRootObjectNode(JsonParser parser) throws IOException {
+  public static ObjectNode getRootObjectNode(JsonParser parser) throws JacksonException {
     return (ObjectNode) getRootTreeNode(parser);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/EmbeddedDataSpecificationsDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/EmbeddedDataSpecificationsDeserializer.java
@@ -15,12 +15,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -29,26 +23,32 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.Reflection
 import org.eclipse.digitaltwin.aas4j.v3.model.DataSpecificationContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ObjectNode;
 
 public class EmbeddedDataSpecificationsDeserializer
-    extends JsonDeserializer<DataSpecificationContent> {
+    extends ValueDeserializer<DataSpecificationContent> {
 
   private static final Logger logger =
       LoggerFactory.getLogger(EmbeddedDataSpecificationsDeserializer.class);
 
   @Override
   public DataSpecificationContent deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException {
+      throws JacksonException {
     ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
     if (node == null) {
       return null;
     }
-
-    return createEmbeddedDataSpecificationsFromContent(parser, node);
+    return createEmbeddedDataSpecificationsFromContent(ctxt, parser, node);
   }
 
   private DataSpecificationContent createEmbeddedDataSpecificationsFromContent(
-      JsonParser parser, JsonNode node) throws IOException {
+      DeserializationContext ctxt, JsonParser parser, JsonNode node) throws JacksonException {
     JsonNode contentNode = node;
     if (contentNode.isObject() && contentNode.has("dataSpecificationContent")) {
       contentNode = contentNode.get("dataSpecificationContent");
@@ -59,39 +59,39 @@ public class EmbeddedDataSpecificationsDeserializer
 
     Set<Class<?>> subtypes = ReflectionHelper.SUBTYPES.get(DataSpecificationContent.class);
     if (subtypes == null || subtypes.isEmpty()) {
-      throw new IOException("No known subtypes of DataSpecificationContent registered");
+      throw DatabindException.from(
+          parser, "No known subtypes of DataSpecificationContent registered");
     }
     if (contentNode.isObject()) {
-      Iterator<Map.Entry<String, JsonNode>> fields = contentNode.fields();
-      while (fields.hasNext()) {
-        Map.Entry<String, JsonNode> field = fields.next();
+      for (Map.Entry<String, JsonNode> field : contentNode.properties()) {
         DataSpecificationContent content =
-            tryDeserializeDataSpecification(parser, field.getKey(), field.getValue(), subtypes);
+            tryDeserializeDataSpecification(ctxt, field.getKey(), field.getValue(), subtypes);
         if (content != null) {
           return content;
         }
       }
     }
 
-    DataSpecificationContent direct = tryDeserializeFromNode(parser, contentNode, subtypes);
+    DataSpecificationContent direct = tryDeserializeFromNode(ctxt, contentNode, subtypes);
     if (direct != null) {
       return direct;
     }
 
-    throw new IOException(
+    throw DatabindException.from(
+        parser,
         "Was expecting a known subclass of DataSpecificationContent but found " + contentNode);
   }
 
   private DataSpecificationContent tryDeserializeDataSpecification(
-      JsonParser parser, String fieldName, JsonNode fieldValue, Set<Class<?>> subtypes)
-      throws IOException {
+      DeserializationContext ctxt, String fieldName, JsonNode fieldValue, Set<Class<?>> subtypes)
+      throws JacksonException {
     Iterator<Class<?>> iter = subtypes.iterator();
     while (iter.hasNext()) {
       Class<?> clazz = iter.next();
       if (matchesType(fieldName, clazz)) {
         try {
           return (DataSpecificationContent)
-              DeserializationHelper.createInstanceFromNode(parser, fieldValue, clazz);
+              DeserializationHelper.createInstanceFromNode(ctxt, fieldValue, clazz);
         } catch (Exception e) {
           if (logger.isDebugEnabled()) {
             logger.debug(
@@ -107,11 +107,11 @@ public class EmbeddedDataSpecificationsDeserializer
   }
 
   private DataSpecificationContent tryDeserializeFromNode(
-      JsonParser parser, JsonNode node, Set<Class<?>> subtypes) throws IOException {
+      DeserializationContext ctxt, JsonNode node, Set<Class<?>> subtypes) throws JacksonException {
     for (Class<?> clazz : subtypes) {
       try {
         return (DataSpecificationContent)
-            DeserializationHelper.createInstanceFromNode(parser, node, clazz);
+            DeserializationHelper.createInstanceFromNode(ctxt, node, clazz);
       } catch (Exception e) {
         if (logger.isDebugEnabled()) {
           logger.debug(

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/KeyDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/KeyDeserializer.java
@@ -15,25 +15,21 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultKey;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class KeyDeserializer implements CustomJsonNodeDeserializer<Key> {
 
   @Override
-  public Key readValue(JsonNode node, JsonParser parser) throws IOException {
+  public Key readValue(JsonNode node, DeserializationContext ctxt) throws JacksonException {
     JsonNode typeNode = node.get("type");
     JsonNode valueNode = node.get("value");
-    KeyTypes type = createKeyTypesFromNode(parser, typeNode);
+    KeyTypes type = DeserializationHelper.createInstanceFromNode(ctxt, typeNode, KeyTypes.class);
     String value = valueNode.asText();
     return new DefaultKey.Builder().type(type).value(value).build();
-  }
-
-  private KeyTypes createKeyTypesFromNode(JsonParser parser, JsonNode typeNode) throws IOException {
-    return DeserializationHelper.createInstanceFromNode(parser, typeNode, KeyTypes.class);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/LangStringContentDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/LangStringContentDeserializer.java
@@ -15,15 +15,16 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.util.LangStringContent;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class LangStringContentDeserializer
     implements CustomJsonNodeDeserializer<LangStringContent> {
   @Override
-  public LangStringContent readValue(JsonNode node, JsonParser parser) throws IOException {
+  public LangStringContent readValue(JsonNode node, DeserializationContext ctxt)
+      throws JacksonException {
     String lang = node.get("language").asText();
     String text = node.get("text").asText();
     return new LangStringContent(lang, text);

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/NoEntryWrapperListDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/NoEntryWrapperListDeserializer.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
@@ -45,7 +46,7 @@ public class NoEntryWrapperListDeserializer<T> extends ValueDeserializer<List<T>
 
   @Override
   public List<T> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     try {
       ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
       JsonNode langStringNode = node.get(elementName);
@@ -62,7 +63,7 @@ public class NoEntryWrapperListDeserializer<T> extends ValueDeserializer<List<T>
   }
 
   private List<T> createEntriesFromArrayNode(ArrayNode langStringsNode, DeserializationContext ctxt)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     List<T> entries = new ArrayList<>();
     for (int i = 0; i < langStringsNode.size(); i++) {
       JsonNode nextNode = langStringsNode.get(i);
@@ -72,7 +73,7 @@ public class NoEntryWrapperListDeserializer<T> extends ValueDeserializer<List<T>
   }
 
   private List<T> createEntriesFromObjectNode(JsonNode langStringNode, DeserializationContext ctxt)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     T entry = nodeDeserializer.readValue(langStringNode, ctxt);
     return Lists.newArrayList(entry);
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/NoEntryWrapperListDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/NoEntryWrapperListDeserializer.java
@@ -15,26 +15,24 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Custom deserializer for lists without individual list entry wrappers for parametrized classes.
  *
  * @param <T> deserialized class within the list
  */
-public class NoEntryWrapperListDeserializer<T> extends JsonDeserializer<List<T>> {
+public class NoEntryWrapperListDeserializer<T> extends ValueDeserializer<List<T>> {
   protected final String elementName;
   private CustomJsonNodeDeserializer<T> nodeDeserializer;
   private static Logger logger = LoggerFactory.getLogger(NoEntryWrapperListDeserializer.class);
@@ -47,14 +45,14 @@ public class NoEntryWrapperListDeserializer<T> extends JsonDeserializer<List<T>>
 
   @Override
   public List<T> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     try {
       ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
       JsonNode langStringNode = node.get(elementName);
       if (langStringNode.isObject()) {
-        return createEntriesFromObjectNode(langStringNode, parser);
+        return createEntriesFromObjectNode(langStringNode, ctxt);
       } else {
-        return createEntriesFromArrayNode((ArrayNode) langStringNode, parser);
+        return createEntriesFromArrayNode((ArrayNode) langStringNode, ctxt);
       }
     } catch (ClassCastException e) {
       logger.info(
@@ -63,19 +61,19 @@ public class NoEntryWrapperListDeserializer<T> extends JsonDeserializer<List<T>>
     }
   }
 
-  private List<T> createEntriesFromArrayNode(ArrayNode langStringsNode, JsonParser parser)
-      throws IOException {
+  private List<T> createEntriesFromArrayNode(ArrayNode langStringsNode, DeserializationContext ctxt)
+      throws tools.jackson.core.JacksonException {
     List<T> entries = new ArrayList<>();
     for (int i = 0; i < langStringsNode.size(); i++) {
       JsonNode nextNode = langStringsNode.get(i);
-      entries.add(nodeDeserializer.readValue(nextNode, parser));
+      entries.add(nodeDeserializer.readValue(nextNode, ctxt));
     }
     return entries;
   }
 
-  private List<T> createEntriesFromObjectNode(JsonNode langStringNode, JsonParser parser)
-      throws IOException {
-    T entry = nodeDeserializer.readValue(langStringNode, parser);
+  private List<T> createEntriesFromObjectNode(JsonNode langStringNode, DeserializationContext ctxt)
+      throws tools.jackson.core.JacksonException {
+    T entry = nodeDeserializer.readValue(langStringNode, ctxt);
     return Lists.newArrayList(entry);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/OperationDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/OperationDeserializer.java
@@ -16,24 +16,23 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.*;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultOperation;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
-public class OperationDeserializer extends JsonDeserializer<Operation> {
+public class OperationDeserializer extends ValueDeserializer<Operation> {
 
   @Override
-  public Operation deserialize(JsonParser parser, DeserializationContext deserializationContext)
-      throws IOException, JacksonException {
+  public Operation deserialize(JsonParser parser, DeserializationContext ctxt)
+      throws JacksonException {
     ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
     JsonNode embeddedDataSpecificationsNode = node.get("embeddedDataSpecifications");
     JsonNode extensionsNode = node.get("extensions");
@@ -50,7 +49,7 @@ public class OperationDeserializer extends JsonDeserializer<Operation> {
     DefaultOperation.Builder builder = new DefaultOperation.Builder();
     List<EmbeddedDataSpecification> embeddedDataSpecifications =
         readWrappedList(
-            parser,
+            ctxt,
             embeddedDataSpecificationsNode,
             "embeddedDataSpecification",
             EmbeddedDataSpecification.class);
@@ -59,38 +58,37 @@ public class OperationDeserializer extends JsonDeserializer<Operation> {
     }
 
     List<Extension> extensions =
-        readWrappedList(parser, extensionsNode, "extension", Extension.class);
+        readWrappedList(ctxt, extensionsNode, "extension", Extension.class);
     if (extensions != null) {
       builder.extensions(extensions);
     }
 
     List<Reference> supplementalSemanticIds =
-        readWrappedList(parser, supplementalSemanticIdsNode, "reference", Reference.class);
+        readWrappedList(ctxt, supplementalSemanticIdsNode, "reference", Reference.class);
     if (supplementalSemanticIds != null) {
       builder.supplementalSemanticIds(supplementalSemanticIds);
     }
 
     List<OperationVariable> inoutputVariables =
-        readWrappedList(
-            parser, inoutputVariablesNode, "operationVariable", OperationVariable.class);
+        readWrappedList(ctxt, inoutputVariablesNode, "operationVariable", OperationVariable.class);
     if (inoutputVariables != null) {
       builder.inoutputVariables(inoutputVariables);
     }
 
     List<OperationVariable> inputVariables =
-        readWrappedList(parser, inputVariablesNode, "operationVariable", OperationVariable.class);
+        readWrappedList(ctxt, inputVariablesNode, "operationVariable", OperationVariable.class);
     if (inputVariables != null) {
       builder.inputVariables(inputVariables);
     }
 
     List<OperationVariable> outputVariables =
-        readWrappedList(parser, outputVariablesNode, "operationVariable", OperationVariable.class);
+        readWrappedList(ctxt, outputVariablesNode, "operationVariable", OperationVariable.class);
     if (outputVariables != null) {
       builder.outputVariables(outputVariables);
     }
 
     List<Qualifier> qualifiers =
-        readWrappedList(parser, qualifiersNode, "qualifier", Qualifier.class);
+        readWrappedList(ctxt, qualifiersNode, "qualifier", Qualifier.class);
     if (qualifiers != null) {
       builder.qualifiers(qualifiers);
     }
@@ -100,13 +98,13 @@ public class OperationDeserializer extends JsonDeserializer<Operation> {
     }
 
     List<LangStringTextType> description =
-        readWrappedList(parser, descriptionNode, "langStringTextType", LangStringTextType.class);
+        readWrappedList(ctxt, descriptionNode, "langStringTextType", LangStringTextType.class);
     if (description != null) {
       builder.description(description);
     }
 
     List<LangStringNameType> displayName =
-        readWrappedList(parser, displayNameNode, "langStringNameType", LangStringNameType.class);
+        readWrappedList(ctxt, displayNameNode, "langStringNameType", LangStringNameType.class);
     if (displayName != null) {
       builder.displayName(displayName);
     }
@@ -117,13 +115,14 @@ public class OperationDeserializer extends JsonDeserializer<Operation> {
 
     if (semanticIdNode != null && !semanticIdNode.isNull()) {
       builder.semanticId(
-          DeserializationHelper.createInstanceFromNode(parser, semanticIdNode, Reference.class));
+          DeserializationHelper.createInstanceFromNode(ctxt, semanticIdNode, Reference.class));
     }
     return builder.build();
   }
 
   private static <T> List<T> readWrappedList(
-      JsonParser parser, JsonNode wrapperNode, String itemName, Class<T> clazz) throws IOException {
+      DeserializationContext ctxt, JsonNode wrapperNode, String itemName, Class<T> clazz)
+      throws JacksonException {
     if (wrapperNode == null || wrapperNode.isNull()) {
       return null;
     }
@@ -132,11 +131,10 @@ public class OperationDeserializer extends JsonDeserializer<Operation> {
       return null;
     }
     if (itemsNode.isArray()) {
-      return DeserializationHelper.createInstancesFromArrayNode(
-          parser, (ArrayNode) itemsNode, clazz);
+      return DeserializationHelper.createInstancesFromArrayNode(ctxt, (ArrayNode) itemsNode, clazz);
     }
     List<T> values = new ArrayList<>();
-    values.add(DeserializationHelper.createInstanceFromNode(parser, itemsNode, clazz));
+    values.add(DeserializationHelper.createInstanceFromNode(ctxt, itemsNode, clazz));
     return values;
   }
 

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/OperationVariableDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/OperationVariableDeserializer.java
@@ -16,52 +16,52 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-public class OperationVariableDeserializer extends JsonDeserializer<List<OperationVariable>> {
+public class OperationVariableDeserializer extends ValueDeserializer<List<OperationVariable>> {
 
   @Override
   public List<OperationVariable> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
-    JsonNode rootNode = parser.getCodec().readTree(parser);
+      throws JacksonException {
+    JsonNode rootNode = ctxt.readTree(parser);
     List<OperationVariable> result = new ArrayList<>();
 
     if (rootNode.isArray()) {
       for (JsonNode element : rootNode) {
         if (element.has("operationVariable")) {
-          deserializeOperationVariable(parser, element, result);
+          deserializeOperationVariable(ctxt, element, result);
         }
       }
     } else if (rootNode.isObject()) {
       if (!rootNode.has("operationVariable")) {
         return result;
       }
-      deserializeOperationVariable(parser, rootNode, result);
+      deserializeOperationVariable(ctxt, rootNode, result);
     }
 
     return result;
   }
 
   private static void deserializeOperationVariable(
-      JsonParser parser, JsonNode element, List<OperationVariable> result) throws IOException {
+      DeserializationContext ctxt, JsonNode element, List<OperationVariable> result)
+      throws JacksonException {
     JsonNode opVarNode = element.get("operationVariable");
     if (opVarNode.isArray()) {
       for (JsonNode inner : opVarNode) {
         OperationVariable opVar =
-            DeserializationHelper.createInstanceFromNode(parser, inner, OperationVariable.class);
+            DeserializationHelper.createInstanceFromNode(ctxt, inner, OperationVariable.class);
         result.add(opVar);
       }
     } else {
       OperationVariable opVar =
-          DeserializationHelper.createInstanceFromNode(parser, opVarNode, OperationVariable.class);
+          DeserializationHelper.createInstanceFromNode(ctxt, opVarNode, OperationVariable.class);
       result.add(opVar);
     }
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/QualifierDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/QualifierDeserializer.java
@@ -47,6 +47,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JsonNode;
@@ -60,7 +61,7 @@ public class QualifierDeserializer extends ValueDeserializer<List<Qualifier>> {
 
   @Override
   public List<Qualifier> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     try {
       ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
 
@@ -83,7 +84,7 @@ public class QualifierDeserializer extends ValueDeserializer<List<Qualifier>> {
   }
 
   private List<Qualifier> createConstraintsFromArrayNode(
-      DeserializationContext ctxt, ObjectNode node) throws tools.jackson.core.JacksonException {
+      DeserializationContext ctxt, ObjectNode node) throws JacksonException {
     ArrayNode content = (ArrayNode) node.get("qualifier");
     return DeserializationHelper.createInstancesFromArrayNode(ctxt, content, Qualifier.class);
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/QualifierDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/QualifierDeserializer.java
@@ -41,28 +41,26 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
-public class QualifierDeserializer extends JsonDeserializer<List<Qualifier>> {
+public class QualifierDeserializer extends ValueDeserializer<List<Qualifier>> {
 
   private static Logger logger = LoggerFactory.getLogger(QualifierDeserializer.class);
 
   @Override
   public List<Qualifier> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     try {
       ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
 
@@ -71,10 +69,10 @@ public class QualifierDeserializer extends JsonDeserializer<List<Qualifier>> {
       }
       JsonNode qualifierNode = node.get("qualifier");
       if (qualifierNode.isArray()) {
-        return createConstraintsFromArrayNode(parser, node);
+        return createConstraintsFromArrayNode(ctxt, node);
       } else {
         Qualifier qualifier =
-            DeserializationHelper.createInstanceFromNode(parser, qualifierNode, Qualifier.class);
+            DeserializationHelper.createInstanceFromNode(ctxt, qualifierNode, Qualifier.class);
         return Lists.newArrayList(qualifier);
       }
     } catch (ClassCastException e) {
@@ -84,9 +82,9 @@ public class QualifierDeserializer extends JsonDeserializer<List<Qualifier>> {
     }
   }
 
-  private List<Qualifier> createConstraintsFromArrayNode(JsonParser parser, ObjectNode node)
-      throws IOException {
+  private List<Qualifier> createConstraintsFromArrayNode(
+      DeserializationContext ctxt, ObjectNode node) throws tools.jackson.core.JacksonException {
     ArrayNode content = (ArrayNode) node.get("qualifier");
-    return DeserializationHelper.createInstancesFromArrayNode(parser, content, Qualifier.class);
+    return DeserializationHelper.createInstancesFromArrayNode(ctxt, content, Qualifier.class);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/ReferencesDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/ReferencesDeserializer.java
@@ -15,50 +15,46 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.TreeNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
-public class ReferencesDeserializer extends JsonDeserializer<List<Reference>> {
+public class ReferencesDeserializer extends ValueDeserializer<List<Reference>> {
 
   @Override
   public List<Reference> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     TreeNode treeNode = DeserializationHelper.getRootTreeNode(parser);
     treeNode = treeNode.get("reference");
     if (treeNode.isArray()) {
-      return createReferencesFromArray(parser, (ArrayNode) treeNode);
+      return createReferencesFromArray(ctxt, (ArrayNode) treeNode);
     } else {
-      return createReferencesFromObjectNode(parser, (ObjectNode) treeNode);
+      return createReferencesFromObjectNode(ctxt, (ObjectNode) treeNode);
     }
   }
 
-  private List<Reference> createReferencesFromObjectNode(JsonParser parser, ObjectNode node)
-      throws IOException {
-    Reference reference = createReference(parser, node);
+  private List<Reference> createReferencesFromObjectNode(
+      DeserializationContext ctxt, ObjectNode node) throws JacksonException {
+    Reference reference = DeserializationHelper.createInstanceFromNode(ctxt, node, Reference.class);
     return Lists.newArrayList(reference);
   }
 
-  private List<Reference> createReferencesFromArray(JsonParser parser, ArrayNode arrayNode)
-      throws IOException {
+  private List<Reference> createReferencesFromArray(
+      DeserializationContext ctxt, ArrayNode arrayNode) throws JacksonException {
     List<Reference> references = new ArrayList<>();
     for (int i = 0; i < arrayNode.size(); i++) {
-      Reference reference = createReference(parser, (ObjectNode) arrayNode.get(i));
+      Reference reference =
+          DeserializationHelper.createInstanceFromNode(ctxt, arrayNode.get(i), Reference.class);
       references.add(reference);
     }
     return references;
-  }
-
-  private Reference createReference(JsonParser parser, ObjectNode node) throws IOException {
-    return DeserializationHelper.createInstanceFromNode(parser, node, Reference.class);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/SubmodelElementDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/SubmodelElementDeserializer.java
@@ -15,59 +15,50 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyName;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.PropertyName;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.introspect.AnnotatedMember;
+import tools.jackson.databind.introspect.BeanPropertyDefinition;
+import tools.jackson.databind.node.ObjectNode;
 
-public class SubmodelElementDeserializer extends JsonDeserializer<SubmodelElement> {
+public class SubmodelElementDeserializer extends ValueDeserializer<SubmodelElement> {
 
   @Override
   public SubmodelElement deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     ObjectNode node = DeserializationHelper.getRootObjectNode(parser);
     String elemName = findSubmodelElementName(parser, node);
     JsonNode nodeContent = node.get(elemName);
     Class<?> clazz = SubmodelElementManager.getClassByXmlName(elemName);
-    JsonNode normalizedNode = unwrapWrappedLists(parser, nodeContent, clazz);
+    JsonNode normalizedNode = unwrapWrappedLists(ctxt, nodeContent, clazz);
     return (SubmodelElement)
-        DeserializationHelper.createInstanceFromNode(parser, normalizedNode, clazz);
+        DeserializationHelper.createInstanceFromNode(ctxt, normalizedNode, clazz);
   }
 
   private String findSubmodelElementName(JsonParser parser, ObjectNode node)
-      throws JsonMappingException {
+      throws DatabindException {
     for (String value : SubmodelElementManager.NAME_TO_CLASS.keySet()) {
       if (node.has(value)) {
         return value;
       }
     }
-    throw new JsonMappingException(parser, "Unknown element " + node);
+    throw DatabindException.from(parser, "Unknown element " + node);
   }
 
-  private JsonNode unwrapWrappedLists(JsonParser parser, JsonNode node, Class<?> clazz) {
+  private JsonNode unwrapWrappedLists(DeserializationContext ctxt, JsonNode node, Class<?> clazz) {
     if (!(node instanceof ObjectNode)) {
       return node;
     }
-    ObjectCodec codec = parser.getCodec();
-    if (!(codec instanceof ObjectMapper)) {
-      return node;
-    }
-    ObjectMapper mapper = (ObjectMapper) codec;
-    BeanDescription desc =
-        mapper.getDeserializationConfig().introspect(mapper.constructType(clazz));
+    BeanDescription desc = ctxt.introspectBeanDescriptionForCreation(ctxt.constructType(clazz));
     ObjectNode objectNode = (ObjectNode) node;
     for (BeanPropertyDefinition prop : desc.findProperties()) {
       if (hasCustomDeserializer(prop)) {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/SubmodelElementsDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/SubmodelElementsDeserializer.java
@@ -15,23 +15,22 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.TreeNode;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
-public class SubmodelElementsDeserializer extends JsonDeserializer<List<SubmodelElement>> {
+public class SubmodelElementsDeserializer extends ValueDeserializer<List<SubmodelElement>> {
 
   private SubmodelElementDeserializer deserializer = new SubmodelElementDeserializer();
 
@@ -43,9 +42,9 @@ public class SubmodelElementsDeserializer extends JsonDeserializer<List<Submodel
 
   @Override
   public List<SubmodelElement> deserialize(JsonParser parser, DeserializationContext ctxt)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
     TreeNode treeNode = DeserializationHelper.getRootTreeNode(parser);
-    if (treeNode instanceof TextNode) {
+    if (treeNode instanceof StringNode) {
       return new ArrayList<>();
     } else {
       return createSubmodelElements(parser, ctxt, treeNode);
@@ -53,8 +52,7 @@ public class SubmodelElementsDeserializer extends JsonDeserializer<List<Submodel
   }
 
   private List<SubmodelElement> createSubmodelElements(
-      JsonParser parser, DeserializationContext ctxt, TreeNode treeNode)
-      throws IOException, JsonProcessingException {
+      JsonParser parser, DeserializationContext ctxt, TreeNode treeNode) throws JacksonException {
     if (treeNode.isArray()) {
       return getSubmodelElementsFromArrayNode(parser, ctxt, (ArrayNode) treeNode);
     } else {
@@ -64,14 +62,14 @@ public class SubmodelElementsDeserializer extends JsonDeserializer<List<Submodel
 
   private List<SubmodelElement> getSubmodelElementsFromObjectNode(
       JsonParser parser, DeserializationContext ctxt, JsonNode nodeSubmodelElement)
-      throws IOException, JsonProcessingException {
+      throws JacksonException {
 
-    Iterator<String> iter = nodeSubmodelElement.fieldNames();
+    Iterator<String> iter = nodeSubmodelElement.propertyNames().iterator();
     List<SubmodelElement> submodelElements = new ArrayList<SubmodelElement>();
 
     while (iter.hasNext()) {
       String submodelElementName = iter.next();
-      final ObjectMapper mapper = new ObjectMapper();
+      final JsonMapper mapper = JsonMapper.builder().build();
       final ObjectNode node = mapper.createObjectNode();
       node.set(submodelElementName, nodeSubmodelElement.get(submodelElementName));
       if (nodeSubmodelElement.get(submodelElementName).isArray()) {
@@ -91,8 +89,7 @@ public class SubmodelElementsDeserializer extends JsonDeserializer<List<Submodel
   }
 
   private List<SubmodelElement> getSubmodelElementsFromArrayNode(
-      JsonParser parser, DeserializationContext ctxt, ArrayNode arrayNode)
-      throws IOException, JsonProcessingException {
+      JsonParser parser, DeserializationContext ctxt, ArrayNode arrayNode) throws JacksonException {
     List<SubmodelElement> elements = new ArrayList<>();
     for (int i = 0; i < arrayNode.size(); i++) {
       JsonNode jsonNode = arrayNode.get(i);
@@ -104,9 +101,8 @@ public class SubmodelElementsDeserializer extends JsonDeserializer<List<Submodel
 
   private SubmodelElement getSubmodelElementFromJsonNode(
       JsonParser parser, DeserializationContext ctxt, JsonNode nodeSubmodelElement)
-      throws IOException, JsonProcessingException {
-    JsonParser parserReference =
-        parser.getCodec().getFactory().getCodec().treeAsTokens(nodeSubmodelElement);
-    return deserializer.deserialize(parserReference, ctxt);
+      throws JacksonException {
+    return DeserializationHelper.createInstanceFromNode(
+        ctxt, nodeSubmodelElement, SubmodelElement.class);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/ValueReferencePairNodeDeserializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/deserialization/ValueReferencePairNodeDeserializer.java
@@ -17,12 +17,12 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.ValueReferencePair;
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultValueReferencePair;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 public class ValueReferencePairNodeDeserializer
     implements CustomJsonNodeDeserializer<ValueReferencePair> {
@@ -30,13 +30,14 @@ public class ValueReferencePairNodeDeserializer
   public static final String VALUE_ID = "valueId";
 
   @Override
-  public ValueReferencePair readValue(JsonNode node, JsonParser parser) throws IOException {
+  public ValueReferencePair readValue(JsonNode node, DeserializationContext ctxt)
+      throws JacksonException {
     String value = node.get("value").asText();
 
     if (!node.has(VALUE_ID)) return new DefaultValueReferencePair.Builder().value(value).build();
 
     Reference valueId =
-        DeserializationHelper.createInstanceFromNode(parser, node.get(VALUE_ID), Reference.class);
+        DeserializationHelper.createInstanceFromNode(ctxt, node.get(VALUE_ID), Reference.class);
     return new DefaultValueReferencePair.Builder().value(value).valueId(valueId).build();
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/AnnotatedRelationshipElementMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/AnnotatedRelationshipElementMixin.java
@@ -15,12 +15,12 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.DataElementsDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.DataElementsSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataElement;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 public interface AnnotatedRelationshipElementMixin {
   @JsonSerialize(using = DataElementsSerializer.class)

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/AssetAdministrationShellMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/AssetAdministrationShellMixin.java
@@ -16,11 +16,11 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "extensions",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/AssetInformationMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/AssetInformationMixin.java
@@ -17,12 +17,12 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.File;
 import org.eclipse.digitaltwin.aas4j.v3.model.SpecificAssetId;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "assetKind",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ConceptDescriptionMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ConceptDescriptionMixin.java
@@ -16,11 +16,11 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "extensions",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/DataSpecificationIec61360Mixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/DataSpecificationIec61360Mixin.java
@@ -16,9 +16,6 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.serialization.EnumSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
@@ -35,6 +32,9 @@ import org.eclipse.digitaltwin.aas4j.v3.model.LangStringShortNameTypeIec61360;
 import org.eclipse.digitaltwin.aas4j.v3.model.LevelType;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.ValueList;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "preferredName",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/EmbeddedDataSpecificationMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/EmbeddedDataSpecificationMixin.java
@@ -16,14 +16,14 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.EmbeddedDataSpecificationsDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.EmbeddedDataSpecificationSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataSpecificationContent;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"dataSpecification", "dataSpecificationContent"})
 public interface EmbeddedDataSpecificationMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/EntityMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/EntityMixin.java
@@ -16,14 +16,14 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.SubmodelElementsDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.SubmodelElementsSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface EntityMixin {
   @JacksonXmlProperty(namespace = AasXmlNamespaceContext.AAS_URI, localName = "statements")

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/EnvironmentMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/EnvironmentMixin.java
@@ -16,13 +16,13 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
 import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "assetAdministrationShells",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ExtensionMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ExtensionMixin.java
@@ -16,10 +16,10 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.RefersToSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.databind.annotation.JsonSerialize;
 
 @JsonPropertyOrder({
   "semanticId",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/HasDataSpecificationMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/HasDataSpecificationMixin.java
@@ -15,11 +15,11 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.EmbeddedDataSpecification;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface HasDataSpecificationMixin {
 

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/HasExtensionsMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/HasExtensionsMixin.java
@@ -15,11 +15,11 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface HasExtensionsMixin {
   @JacksonXmlProperty(namespace = AasXmlNamespaceContext.AAS_URI, localName = "extension")

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/HasSemanticsMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/HasSemanticsMixin.java
@@ -16,13 +16,13 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.ReferencesDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder("semanticId, supplementalSemanticIds")
 public interface HasSemanticsMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/KeyMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/KeyMixin.java
@@ -16,9 +16,9 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"type", "value"})
 public interface KeyMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/LevelTypeMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/LevelTypeMixin.java
@@ -17,8 +17,8 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"min", "nom", "typ", "max"})
 public interface LevelTypeMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/MultiLanguagePropertyMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/MultiLanguagePropertyMixin.java
@@ -15,14 +15,14 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.LangStringsTextTypeDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface MultiLanguagePropertyMixin {
   @JacksonXmlElementWrapper(namespace = AasXmlNamespaceContext.AAS_URI, localName = "value")

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/OperationMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/OperationMixin.java
@@ -15,10 +15,10 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.OperationVariableDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 public interface OperationMixin {
   @JsonDeserialize(using = OperationVariableDeserializer.class)

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/OperationVariableMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/OperationVariableMixin.java
@@ -15,13 +15,13 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.SubmodelElementDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.SubmodelElementSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface OperationVariableMixin {
 

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/PropertyMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/PropertyMixin.java
@@ -15,9 +15,9 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * @author schnicke

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/QualifiableMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/QualifiableMixin.java
@@ -15,13 +15,13 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.QualifierDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Qualifier;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface QualifiableMixin {
   @JacksonXmlElementWrapper(namespace = AasXmlNamespaceContext.AAS_URI, localName = "qualifiers")

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/QualifierMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/QualifierMixin.java
@@ -17,11 +17,11 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
 import org.eclipse.digitaltwin.aas4j.v3.model.QualifierKind;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "semanticId",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ReferableMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ReferableMixin.java
@@ -16,9 +16,6 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.LangStringsNameTypeDeserializer;
@@ -27,6 +24,9 @@ import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.La
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.LangStringsTextTypeSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "hasExtensions",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ReferenceMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ReferenceMixin.java
@@ -16,15 +16,15 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.KeysDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceTypes;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"type", "referredSemanticId", "key"})
 public interface ReferenceMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ResourceMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ResourceMixin.java
@@ -17,9 +17,9 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"path", "contentType"})
 public interface ResourceMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SpecificAssetIdMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SpecificAssetIdMixin.java
@@ -16,9 +16,9 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"semanticId", "supplementalSemanticIds", "name", "value", "externalSubjectId"})
 public interface SpecificAssetIdMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SubmodelElementCollectionMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SubmodelElementCollectionMixin.java
@@ -15,14 +15,14 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.SubmodelElementsDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.SubmodelElementsSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface SubmodelElementCollectionMixin {
   @JacksonXmlProperty(namespace = AasXmlNamespaceContext.AAS_URI, localName = "value")

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SubmodelElementListMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SubmodelElementListMixin.java
@@ -16,9 +16,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.SubmodelElementsDeserializer;
@@ -27,6 +24,9 @@ import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface SubmodelElementListMixin {
   @JacksonXmlProperty(namespace = AasXmlNamespaceContext.AAS_URI, localName = "value")

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SubmodelMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/SubmodelMixin.java
@@ -16,14 +16,14 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.SubmodelElementsDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization.SubmodelElementsSerializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({
   "extensions",

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ValueListMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ValueListMixin.java
@@ -15,13 +15,13 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.deserialization.ValueReferencePairsDeserializer;
 import org.eclipse.digitaltwin.aas4j.v3.model.ValueReferencePair;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 public interface ValueListMixin {
 

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ValueReferencePairMixin.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/mixins/ValueReferencePairMixin.java
@@ -16,9 +16,9 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 @JsonPropertyOrder({"value", "valueID"})
 public interface ValueReferencePairMixin {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringSerializer.java
@@ -17,6 +17,8 @@
 /** */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
+import java.lang.reflect.Field;
+import javax.xml.namespace.QName;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
 import tools.jackson.core.JacksonException;
@@ -24,9 +26,6 @@ import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
-
-import javax.xml.namespace.QName;
-import java.lang.reflect.Field;
 
 public class AbstractLangStringSerializer<T extends AbstractLangString> extends ValueSerializer<T> {
 

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringSerializer.java
@@ -17,17 +17,16 @@
 /** */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import javax.xml.namespace.QName;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-public class AbstractLangStringSerializer<T extends AbstractLangString> extends JsonSerializer<T> {
+public class AbstractLangStringSerializer<T extends AbstractLangString> extends ValueSerializer<T> {
 
   private String name;
 
@@ -36,8 +35,8 @@ public class AbstractLangStringSerializer<T extends AbstractLangString> extends 
   }
 
   @Override
-  public void serialize(T langString, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(T langString, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     try {
       Field nextName = xgen.getClass().getDeclaredField("_nextName");
@@ -53,12 +52,12 @@ public class AbstractLangStringSerializer<T extends AbstractLangString> extends 
   }
 
   protected void serializeLangStringContent(ToXmlGenerator xgen, AbstractLangString langString)
-      throws IOException {
+      throws tools.jackson.core.JacksonException {
     xgen.writeStartObject();
-    xgen.writeFieldName("language");
+    xgen.writeName("language");
     xgen.writeString(langString.getLanguage());
 
-    xgen.writeFieldName("text");
+    xgen.writeName("text");
     xgen.writeString(langString.getText());
 
     xgen.writeEndObject();

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringSerializer.java
@@ -17,14 +17,16 @@
 /** */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import java.lang.reflect.Field;
-import javax.xml.namespace.QName;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.AasXmlNamespaceContext;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
 import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+import javax.xml.namespace.QName;
+import java.lang.reflect.Field;
 
 public class AbstractLangStringSerializer<T extends AbstractLangString> extends ValueSerializer<T> {
 
@@ -36,7 +38,7 @@ public class AbstractLangStringSerializer<T extends AbstractLangString> extends 
 
   @Override
   public void serialize(T langString, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     try {
       Field nextName = xgen.getClass().getDeclaredField("_nextName");
@@ -52,7 +54,7 @@ public class AbstractLangStringSerializer<T extends AbstractLangString> extends 
   }
 
   protected void serializeLangStringContent(ToXmlGenerator xgen, AbstractLangString langString)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     xgen.writeStartObject();
     xgen.writeName("language");
     xgen.writeString(langString.getLanguage());

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringsSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringsSerializer.java
@@ -16,14 +16,13 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 /**
  * @author schnicke
@@ -39,8 +38,8 @@ public class AbstractLangStringsSerializer<T extends AbstractLangString>
   }
 
   @Override
-  public void serialize(List<T> langStrings, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(List<T> langStrings, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     xgen.writeStartObject();
@@ -49,7 +48,7 @@ public class AbstractLangStringsSerializer<T extends AbstractLangString>
           ReflectionHelper.setEmptyListsToNull(
               element); // call is needed to prevent empty tags (e.g. statements.size=0 leads to
       // <statements />, which is not allowed according to the schema
-      xgen.writeFieldName(SubmodelElementManager.getXmlName(element.getClass()));
+      xgen.writeName(SubmodelElementManager.getXmlName(element.getClass()));
       ser.serialize(element, xgen, serializers);
 
       resetRunnables.stream().forEach(r -> r.run());

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringsSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AbstractLangStringsSerializer.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.AbstractLangString;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
@@ -39,7 +40,7 @@ public class AbstractLangStringsSerializer<T extends AbstractLangString>
 
   @Override
   public void serialize(List<T> langStrings, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     xgen.writeStartObject();

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AssetAdministrationShellEnvironmentSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AssetAdministrationShellEnvironmentSerializer.java
@@ -28,6 +28,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -66,7 +67,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
 
   @Override
   public void serialize(Environment value, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     XMLStreamWriter streamWriter = xgen.getStaxWriter();
     setPrefixes(streamWriter);
@@ -86,7 +87,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
   }
 
   private void writeOpeningTag(ToXmlGenerator xgen, XMLStreamWriter streamWriter)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     xgen.setNextName(AASENV_TAGNAME);
     xgen.writeStartObject();
     try {
@@ -99,16 +100,14 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
     }
   }
 
-  private void writeContent(Environment value, ToXmlGenerator xgen)
-      throws tools.jackson.core.JacksonException {
+  private void writeContent(Environment value, ToXmlGenerator xgen) throws JacksonException {
     writeAssetAdministrationShells(xgen, value.getAssetAdministrationShells());
     writeSubmodels(xgen, value.getSubmodels());
     writeConceptDescriptions(xgen, value.getConceptDescriptions());
   }
 
   private void writeAssetAdministrationShells(
-      ToXmlGenerator xgen, List<AssetAdministrationShell> aasList)
-      throws tools.jackson.core.JacksonException {
+      ToXmlGenerator xgen, List<AssetAdministrationShell> aasList) throws JacksonException {
     if (aasList.isEmpty()) {
       return;
     }
@@ -116,8 +115,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
   }
 
   private void writeConceptDescriptions(
-      ToXmlGenerator xgen, List<ConceptDescription> conceptDescriptions)
-      throws tools.jackson.core.JacksonException {
+      ToXmlGenerator xgen, List<ConceptDescription> conceptDescriptions) throws JacksonException {
     if (conceptDescriptions.isEmpty()) {
       return;
     }
@@ -126,7 +124,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
   }
 
   private void writeSubmodels(ToXmlGenerator xgen, List<Submodel> submodels)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     if (submodels.isEmpty()) {
       return;
     }
@@ -134,7 +132,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
   }
 
   private void writeWrappedArray(ToXmlGenerator xgen, QName wrapper, QName wrapped, List<?> list)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     // overwrite all empty list with null, as the schema does not allow empty XML lists
 
     List<Runnable> resetRunnables = new ArrayList<>();
@@ -153,7 +151,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializ
     resetRunnables.stream().forEach(r -> r.run());
   }
 
-  private void closeOpeningTag(ToXmlGenerator xgen) throws tools.jackson.core.JacksonException {
+  private void closeOpeningTag(ToXmlGenerator xgen) throws JacksonException {
     xgen.writeEndObject();
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AssetAdministrationShellEnvironmentSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/AssetAdministrationShellEnvironmentSerializer.java
@@ -15,11 +15,6 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +28,12 @@ import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
 import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-public class AssetAdministrationShellEnvironmentSerializer extends JsonSerializer<Environment> {
+public class AssetAdministrationShellEnvironmentSerializer extends ValueSerializer<Environment> {
 
   private static final String[] SCHEMA_LOCATION = {
     "xsi:schemaLocation", "https://admin-shell.io/aas/3/1 AAS.xsd"
@@ -66,8 +65,8 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
   }
 
   @Override
-  public void serialize(Environment value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(Environment value, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     XMLStreamWriter streamWriter = xgen.getStaxWriter();
     setPrefixes(streamWriter);
@@ -87,7 +86,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
   }
 
   private void writeOpeningTag(ToXmlGenerator xgen, XMLStreamWriter streamWriter)
-      throws IOException {
+      throws tools.jackson.core.JacksonException {
     xgen.setNextName(AASENV_TAGNAME);
     xgen.writeStartObject();
     try {
@@ -100,14 +99,16 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
     }
   }
 
-  private void writeContent(Environment value, ToXmlGenerator xgen) throws IOException {
+  private void writeContent(Environment value, ToXmlGenerator xgen)
+      throws tools.jackson.core.JacksonException {
     writeAssetAdministrationShells(xgen, value.getAssetAdministrationShells());
     writeSubmodels(xgen, value.getSubmodels());
     writeConceptDescriptions(xgen, value.getConceptDescriptions());
   }
 
   private void writeAssetAdministrationShells(
-      ToXmlGenerator xgen, List<AssetAdministrationShell> aasList) throws IOException {
+      ToXmlGenerator xgen, List<AssetAdministrationShell> aasList)
+      throws tools.jackson.core.JacksonException {
     if (aasList.isEmpty()) {
       return;
     }
@@ -115,7 +116,8 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
   }
 
   private void writeConceptDescriptions(
-      ToXmlGenerator xgen, List<ConceptDescription> conceptDescriptions) throws IOException {
+      ToXmlGenerator xgen, List<ConceptDescription> conceptDescriptions)
+      throws tools.jackson.core.JacksonException {
     if (conceptDescriptions.isEmpty()) {
       return;
     }
@@ -123,7 +125,8 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
         xgen, CONCEPTDICTIONARYLIST_TAGNAME, CONCEPTDICTIONARY_TAGNAME, conceptDescriptions);
   }
 
-  private void writeSubmodels(ToXmlGenerator xgen, List<Submodel> submodels) throws IOException {
+  private void writeSubmodels(ToXmlGenerator xgen, List<Submodel> submodels)
+      throws tools.jackson.core.JacksonException {
     if (submodels.isEmpty()) {
       return;
     }
@@ -131,18 +134,18 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
   }
 
   private void writeWrappedArray(ToXmlGenerator xgen, QName wrapper, QName wrapped, List<?> list)
-      throws IOException {
+      throws tools.jackson.core.JacksonException {
     // overwrite all empty list with null, as the schema does not allow empty XML lists
 
     List<Runnable> resetRunnables = new ArrayList<>();
 
     for (Object obj : list) resetRunnables.addAll(ReflectionHelper.setEmptyListsToNull(obj));
 
-    xgen.writeFieldName(wrapper.getLocalPart());
+    xgen.writeName(wrapper.getLocalPart());
     xgen.writeStartArray();
     xgen.startWrappedValue(wrapper, wrapped);
     for (Object aas : list) {
-      xgen.writeObject(aas);
+      xgen.writePOJO(aas);
     }
     xgen.finishWrappedValue(wrapper, wrapped);
     xgen.writeEndArray();
@@ -150,7 +153,7 @@ public class AssetAdministrationShellEnvironmentSerializer extends JsonSerialize
     resetRunnables.stream().forEach(r -> r.run());
   }
 
-  private void closeOpeningTag(ToXmlGenerator xgen) throws IOException {
+  private void closeOpeningTag(ToXmlGenerator xgen) throws tools.jackson.core.JacksonException {
     xgen.writeEndObject();
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/DataElementsSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/DataElementsSerializer.java
@@ -15,16 +15,15 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-public class DataElementsSerializer extends JsonSerializer<List<SubmodelElement>> {
+public class DataElementsSerializer extends ValueSerializer<List<SubmodelElement>> {
 
   SubmodelElementSerializer ser = new SubmodelElementSerializer();
 
@@ -36,12 +35,12 @@ public class DataElementsSerializer extends JsonSerializer<List<SubmodelElement>
 
   @Override
   public void serialize(
-      List<SubmodelElement> value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      List<SubmodelElement> value, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     xgen.writeStartObject();
     for (SubmodelElement element : value) {
-      xgen.writeFieldName(SubmodelElementManager.getXmlName(element.getClass()));
+      xgen.writeName(SubmodelElementManager.getXmlName(element.getClass()));
       ser.serialize(element, xgen, serializers);
     }
     xgen.writeEndObject();

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/DataElementsSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/DataElementsSerializer.java
@@ -18,6 +18,7 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -36,7 +37,7 @@ public class DataElementsSerializer extends ValueSerializer<List<SubmodelElement
   @Override
   public void serialize(
       List<SubmodelElement> value, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     xgen.writeStartObject();
     for (SubmodelElement element : value) {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/EmbeddedDataSpecificationSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/EmbeddedDataSpecificationSerializer.java
@@ -15,25 +15,23 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.google.common.base.CaseFormat;
-import java.io.IOException;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataSpecificationContent;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.jsontype.TypeSerializer;
 
 /**
  * Custom Serializer for class DataSpecification. Adds type information in form of a reference. Uses
  * DataSpecificationManager to resolve java type to reference.
  */
-public class EmbeddedDataSpecificationSerializer extends JsonSerializer<DataSpecificationContent> {
+public class EmbeddedDataSpecificationSerializer extends ValueSerializer<DataSpecificationContent> {
 
   @Override
   public void serialize(
-      DataSpecificationContent data, JsonGenerator generator, SerializerProvider provider)
-      throws IOException {
+      DataSpecificationContent data, JsonGenerator generator, SerializationContext provider)
+      throws tools.jackson.core.JacksonException {
     if (data == null) {
       return;
     }
@@ -47,7 +45,7 @@ public class EmbeddedDataSpecificationSerializer extends JsonSerializer<DataSpec
     }
     className = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, className);
     generator.writeStartObject();
-    generator.writeObjectField(className, data);
+    generator.writePOJOProperty(className, data);
     generator.writeEndObject();
   }
 
@@ -55,9 +53,9 @@ public class EmbeddedDataSpecificationSerializer extends JsonSerializer<DataSpec
   public void serializeWithType(
       DataSpecificationContent data,
       JsonGenerator generator,
-      SerializerProvider provider,
+      SerializationContext provider,
       TypeSerializer typedSerializer)
-      throws IOException, JsonProcessingException {
+      throws tools.jackson.core.JacksonException {
     serialize(data, generator, provider);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/EmbeddedDataSpecificationSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/EmbeddedDataSpecificationSerializer.java
@@ -17,6 +17,7 @@ package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
 import com.google.common.base.CaseFormat;
 import org.eclipse.digitaltwin.aas4j.v3.model.DataSpecificationContent;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -31,7 +32,7 @@ public class EmbeddedDataSpecificationSerializer extends ValueSerializer<DataSpe
   @Override
   public void serialize(
       DataSpecificationContent data, JsonGenerator generator, SerializationContext provider)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     if (data == null) {
       return;
     }
@@ -55,7 +56,7 @@ public class EmbeddedDataSpecificationSerializer extends ValueSerializer<DataSpe
       JsonGenerator generator,
       SerializationContext provider,
       TypeSerializer typedSerializer)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     serialize(data, generator, provider);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/LangStringsNameTypeSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/LangStringsNameTypeSerializer.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
@@ -35,7 +36,7 @@ public class LangStringsNameTypeSerializer
   @Override
   public void serialize(
       List<LangStringNameType> langStrings, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     xgen.writeStartObject();

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/LangStringsNameTypeSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/LangStringsNameTypeSerializer.java
@@ -15,14 +15,13 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 /**
  * @author schnicke
@@ -35,8 +34,8 @@ public class LangStringsNameTypeSerializer
 
   @Override
   public void serialize(
-      List<LangStringNameType> langStrings, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      List<LangStringNameType> langStrings, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     xgen.writeStartObject();
@@ -45,7 +44,7 @@ public class LangStringsNameTypeSerializer
           ReflectionHelper.setEmptyListsToNull(
               element); // call is needed to prevent empty tags (e.g. statements.size=0 leads to
       // <statements />, which is not allowed according to the schema
-      xgen.writeFieldName(SubmodelElementManager.getXmlName(element.getClass()));
+      xgen.writeName(SubmodelElementManager.getXmlName(element.getClass()));
       ser.serialize(element, xgen, serializers);
       resetRunnables.stream().forEach(r -> r.run());
     }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/NoEntryWrapperListSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/NoEntryWrapperListSerializer.java
@@ -15,19 +15,18 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 /**
  * Custom serializer for lists without individual list entry wrappers for parametrized classes.
  *
  * @param <T> serialized class within the list
  */
-public class NoEntryWrapperListSerializer<T extends Object> extends JsonSerializer<List<T>> {
+public class NoEntryWrapperListSerializer<T extends Object> extends ValueSerializer<List<T>> {
   private String outerWrapperName;
 
   /**
@@ -40,12 +39,13 @@ public class NoEntryWrapperListSerializer<T extends Object> extends JsonSerializ
   }
 
   @Override
-  public void serialize(List<T> list, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(List<T> list, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     writeList(list, (ToXmlGenerator) gen);
   }
 
-  private void writeList(List<T> list, ToXmlGenerator xgen) throws IOException {
+  private void writeList(List<T> list, ToXmlGenerator xgen)
+      throws tools.jackson.core.JacksonException {
     xgen.writeStartObject();
 
     writeOuterWrapperStart(xgen);
@@ -55,26 +55,29 @@ public class NoEntryWrapperListSerializer<T extends Object> extends JsonSerializ
     xgen.writeEndObject();
   }
 
-  private void writeListEntries(List<T> list, ToXmlGenerator xgen) throws IOException {
+  private void writeListEntries(List<T> list, ToXmlGenerator xgen)
+      throws tools.jackson.core.JacksonException {
     for (Object listEntry : list) {
-      xgen.writeObject(listEntry);
+      xgen.writePOJO(listEntry);
     }
   }
 
-  private void writeOuterWrapperStart(ToXmlGenerator xgen) throws IOException {
+  private void writeOuterWrapperStart(ToXmlGenerator xgen)
+      throws tools.jackson.core.JacksonException {
     if (outerWrapperName != null && !outerWrapperName.isEmpty()) {
-      xgen.writeObjectFieldStart(outerWrapperName);
+      xgen.writeObjectPropertyStart(outerWrapperName);
     }
   }
 
-  private void writeOuterWrapperEnd(ToXmlGenerator xgen) throws IOException {
+  private void writeOuterWrapperEnd(ToXmlGenerator xgen)
+      throws tools.jackson.core.JacksonException {
     if (outerWrapperName != null && !outerWrapperName.isEmpty()) {
       xgen.writeEndObject();
     }
   }
 
   @Override
-  public boolean isEmpty(SerializerProvider provider, List<T> value) {
+  public boolean isEmpty(SerializationContext provider, List<T> value) {
     return value == null || value.isEmpty();
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/NoEntryWrapperListSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/NoEntryWrapperListSerializer.java
@@ -16,6 +16,7 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
 import java.util.List;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -40,12 +41,11 @@ public class NoEntryWrapperListSerializer<T extends Object> extends ValueSeriali
 
   @Override
   public void serialize(List<T> list, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     writeList(list, (ToXmlGenerator) gen);
   }
 
-  private void writeList(List<T> list, ToXmlGenerator xgen)
-      throws tools.jackson.core.JacksonException {
+  private void writeList(List<T> list, ToXmlGenerator xgen) throws JacksonException {
     xgen.writeStartObject();
 
     writeOuterWrapperStart(xgen);
@@ -55,22 +55,19 @@ public class NoEntryWrapperListSerializer<T extends Object> extends ValueSeriali
     xgen.writeEndObject();
   }
 
-  private void writeListEntries(List<T> list, ToXmlGenerator xgen)
-      throws tools.jackson.core.JacksonException {
+  private void writeListEntries(List<T> list, ToXmlGenerator xgen) throws JacksonException {
     for (Object listEntry : list) {
       xgen.writePOJO(listEntry);
     }
   }
 
-  private void writeOuterWrapperStart(ToXmlGenerator xgen)
-      throws tools.jackson.core.JacksonException {
+  private void writeOuterWrapperStart(ToXmlGenerator xgen) throws JacksonException {
     if (outerWrapperName != null && !outerWrapperName.isEmpty()) {
       xgen.writeObjectPropertyStart(outerWrapperName);
     }
   }
 
-  private void writeOuterWrapperEnd(ToXmlGenerator xgen)
-      throws tools.jackson.core.JacksonException {
+  private void writeOuterWrapperEnd(ToXmlGenerator xgen) throws JacksonException {
     if (outerWrapperName != null && !outerWrapperName.isEmpty()) {
       xgen.writeEndObject();
     }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationSerializer.java
@@ -21,6 +21,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.Operation;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -29,7 +30,7 @@ public class OperationSerializer extends ValueSerializer<Operation> {
 
   @Override
   public void serialize(Operation operation, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     gen.writeStartObject();
     writeWrappedList(gen, serializers, "extensions", "extension", operation.getExtensions());
     if (operation.getCategory() != null) {
@@ -91,7 +92,7 @@ public class OperationSerializer extends ValueSerializer<Operation> {
       SerializationContext serializers,
       List<OperationVariable> inputVariables,
       String variableType)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     gen.writeName(variableType);
     gen.writeStartObject();
     gen.writeArrayPropertyStart("operationVariable");
@@ -108,7 +109,7 @@ public class OperationSerializer extends ValueSerializer<Operation> {
       String wrapperName,
       String itemName,
       List<T> values)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     if (values == null || values.isEmpty()) {
       return;
     }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationSerializer.java
@@ -16,42 +16,43 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringNameType;
 import org.eclipse.digitaltwin.aas4j.v3.model.LangStringTextType;
 import org.eclipse.digitaltwin.aas4j.v3.model.Operation;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-public class OperationSerializer extends JsonSerializer<Operation> {
+public class OperationSerializer extends ValueSerializer<Operation> {
 
   @Override
-  public void serialize(Operation operation, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(Operation operation, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     gen.writeStartObject();
     writeWrappedList(gen, serializers, "extensions", "extension", operation.getExtensions());
     if (operation.getCategory() != null) {
-      gen.writeStringField("category", operation.getCategory());
+      gen.writeStringProperty("category", operation.getCategory());
     }
     if (operation.getIdShort() != null) {
-      gen.writeStringField("idShort", operation.getIdShort());
+      gen.writeStringProperty("idShort", operation.getIdShort());
     }
     List<LangStringNameType> displayName = operation.getDisplayName();
     if (displayName != null && !displayName.isEmpty()) {
-      gen.writeFieldName("displayName");
+      gen.writeName("displayName");
       new LangStringsNameTypeSerializer().serialize(displayName, gen, serializers);
     }
     List<LangStringTextType> description = operation.getDescription();
     if (description != null && !description.isEmpty()) {
-      gen.writeFieldName("description");
+      gen.writeName("description");
       new LangStringsTextTypeSerializer().serialize(description, gen, serializers);
     }
     if (operation.getSemanticId() != null) {
-      gen.writeFieldName("semanticId");
-      serializers.defaultSerializeValue(operation.getSemanticId(), gen);
+      gen.writeName("semanticId");
+      serializers
+          .findValueSerializer(operation.getSemanticId().getClass())
+          .serialize(operation.getSemanticId(), gen, serializers);
     }
     writeWrappedList(
         gen,
@@ -87,15 +88,15 @@ public class OperationSerializer extends JsonSerializer<Operation> {
 
   private static void serializeOperationVariable(
       JsonGenerator gen,
-      SerializerProvider serializers,
+      SerializationContext serializers,
       List<OperationVariable> inputVariables,
       String variableType)
-      throws IOException {
-    gen.writeFieldName(variableType);
+      throws tools.jackson.core.JacksonException {
+    gen.writeName(variableType);
     gen.writeStartObject();
-    gen.writeArrayFieldStart("operationVariable");
+    gen.writeArrayPropertyStart("operationVariable");
     for (OperationVariable var : inputVariables) {
-      serializers.defaultSerializeValue(var, gen);
+      serializers.findValueSerializer(var.getClass()).serialize(var, gen, serializers);
     }
     gen.writeEndArray();
     gen.writeEndObject();
@@ -103,19 +104,19 @@ public class OperationSerializer extends JsonSerializer<Operation> {
 
   private static <T> void writeWrappedList(
       JsonGenerator gen,
-      SerializerProvider serializers,
+      SerializationContext serializers,
       String wrapperName,
       String itemName,
       List<T> values)
-      throws IOException {
+      throws tools.jackson.core.JacksonException {
     if (values == null || values.isEmpty()) {
       return;
     }
-    gen.writeFieldName(wrapperName);
+    gen.writeName(wrapperName);
     gen.writeStartObject();
-    gen.writeArrayFieldStart(itemName);
+    gen.writeArrayPropertyStart(itemName);
     for (T value : values) {
-      serializers.defaultSerializeValue(value, gen);
+      serializers.findValueSerializer(value.getClass()).serialize(value, gen, serializers);
     }
     gen.writeEndArray();
     gen.writeEndObject();

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationVariableSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationVariableSerializer.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -28,7 +29,7 @@ public class OperationVariableSerializer extends ValueSerializer<OperationVariab
   @Override
   public void serialize(
       OperationVariable operationVariable, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     List<Runnable> resetRunnables =
         ReflectionHelper.setEmptyListsToNull(operationVariable.getValue());

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationVariableSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/OperationVariableSerializer.java
@@ -15,29 +15,28 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationVariable;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-public class OperationVariableSerializer extends JsonSerializer<OperationVariable> {
+public class OperationVariableSerializer extends ValueSerializer<OperationVariable> {
   @Override
   public void serialize(
-      OperationVariable operationVariable, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      OperationVariable operationVariable, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     List<Runnable> resetRunnables =
         ReflectionHelper.setEmptyListsToNull(operationVariable.getValue());
     xgen.writeStartObject();
-    xgen.writeFieldName("value");
+    xgen.writeName("value");
     xgen.writeStartObject();
-    xgen.writeFieldName(SubmodelElementManager.getXmlName(operationVariable.getValue().getClass()));
-    xgen.writeObject(operationVariable.getValue());
+    xgen.writeName(SubmodelElementManager.getXmlName(operationVariable.getValue().getClass()));
+    xgen.writePOJO(operationVariable.getValue());
     xgen.writeEndObject();
     xgen.writeEndObject();
     resetRunnables.stream().forEach(r -> r.run());

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/RefersToSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/RefersToSerializer.java
@@ -25,15 +25,14 @@
 
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins.HasSemanticsMixin;
 import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
 /**
  * Serializes the RefersTo value of {@link Extension}. <br>
@@ -42,11 +41,11 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
  *
  * @author schnicke
  */
-public class RefersToSerializer extends JsonSerializer<List<Reference>> {
+public class RefersToSerializer extends ValueSerializer<List<Reference>> {
 
   @Override
-  public void serialize(List<Reference> value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(List<Reference> value, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     if (value.isEmpty()) return;
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
@@ -60,8 +59,9 @@ public class RefersToSerializer extends JsonSerializer<List<Reference>> {
     xgen.writeEndObject();
   }
 
-  private void writeReference(ToXmlGenerator xgen, Reference ref) throws IOException {
-    xgen.writeFieldName("reference");
-    xgen.writeObject(ref);
+  private void writeReference(ToXmlGenerator xgen, Reference ref)
+      throws tools.jackson.core.JacksonException {
+    xgen.writeName("reference");
+    xgen.writePOJO(ref);
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/RefersToSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/RefersToSerializer.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.mixins.HasSemanticsMixin;
 import org.eclipse.digitaltwin.aas4j.v3.model.Extension;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -45,7 +46,7 @@ public class RefersToSerializer extends ValueSerializer<List<Reference>> {
 
   @Override
   public void serialize(List<Reference> value, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     if (value.isEmpty()) return;
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
@@ -59,8 +60,7 @@ public class RefersToSerializer extends ValueSerializer<List<Reference>> {
     xgen.writeEndObject();
   }
 
-  private void writeReference(ToXmlGenerator xgen, Reference ref)
-      throws tools.jackson.core.JacksonException {
+  private void writeReference(ToXmlGenerator xgen, Reference ref) throws JacksonException {
     xgen.writeName("reference");
     xgen.writePOJO(ref);
   }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementSerializer.java
@@ -15,21 +15,21 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import javax.xml.namespace.QName;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.exc.StreamWriteException;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-public class SubmodelElementSerializer extends JsonSerializer<SubmodelElement> {
+public class SubmodelElementSerializer extends ValueSerializer<SubmodelElement> {
 
   @Override
-  public void serialize(SubmodelElement value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+  public void serialize(SubmodelElement value, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
 
     try {
@@ -40,20 +40,21 @@ public class SubmodelElementSerializer extends JsonSerializer<SubmodelElement> {
       String name = SubmodelElementManager.getXmlName(value.getClass());
 
       if (name != null && next.getLocalPart().equals(name)) {
-        xgen.writeObject(value); // only write the plain object without a deduplicate wrapping field
+        xgen.writePOJO(value); // only write the plain object without a deduplicate wrapping field
         return;
       }
     } catch (NoSuchFieldException | IllegalAccessException e) {
-      throw new IOException(e);
+      throw new StreamWriteException(gen, e.getMessage());
     }
 
     xgen.writeStartObject();
     String name = SubmodelElementManager.getXmlName(value.getClass());
     if (name == null) {
-      throw new IOException("Unknown submodel element type: " + value.getClass().getName());
+      throw new StreamWriteException(
+          gen, "Unknown submodel element type: " + value.getClass().getName());
     }
-    xgen.writeFieldName(name);
-    xgen.writeObject(value);
+    xgen.writeName(name);
+    xgen.writePOJO(value);
     xgen.writeEndObject();
   }
 }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementSerializer.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Field;
 import javax.xml.namespace.QName;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.core.exc.StreamWriteException;
 import tools.jackson.databind.SerializationContext;
@@ -29,7 +30,7 @@ public class SubmodelElementSerializer extends ValueSerializer<SubmodelElement> 
 
   @Override
   public void serialize(SubmodelElement value, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
 
     try {

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementsSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementsSerializer.java
@@ -15,24 +15,23 @@
  */
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.serialization;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
-import java.io.IOException;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
 
-public class SubmodelElementsSerializer extends JsonSerializer<List<SubmodelElement>> {
+public class SubmodelElementsSerializer extends ValueSerializer<List<SubmodelElement>> {
 
   private SubmodelElementSerializer ser = new SubmodelElementSerializer();
 
   @Override
   public void serialize(
-      List<SubmodelElement> value, JsonGenerator gen, SerializerProvider serializers)
-      throws IOException {
+      List<SubmodelElement> value, JsonGenerator gen, SerializationContext serializers)
+      throws tools.jackson.core.JacksonException {
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     // If list is null or contains no non-null elements, omit the wrapper entirely to
@@ -60,7 +59,7 @@ public class SubmodelElementsSerializer extends JsonSerializer<List<SubmodelElem
           ReflectionHelper.setEmptyListsToNull(
               element); // call is needed to prevent empty tags (e.g. statements.size=0 leads to
       // <statements />, which is not allowed according to the schema
-      xgen.writeFieldName(SubmodelElementManager.getXmlName(element.getClass()));
+      xgen.writeName(SubmodelElementManager.getXmlName(element.getClass()));
       ser.serialize(element, xgen, serializers);
       resetRunnables.stream().forEach(r -> r.run());
     }

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementsSerializer.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/internal/serialization/SubmodelElementsSerializer.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.ReflectionHelper;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.xml.internal.SubmodelElementManager;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -31,7 +32,7 @@ public class SubmodelElementsSerializer extends ValueSerializer<List<SubmodelEle
   @Override
   public void serialize(
       List<SubmodelElement> value, JsonGenerator gen, SerializationContext serializers)
-      throws tools.jackson.core.JacksonException {
+      throws JacksonException {
 
     ToXmlGenerator xgen = (ToXmlGenerator) gen;
     // If list is null or contains no non-null elements, omit the wrapper entirely to

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,14 @@
         <module>dataformat-xml</module>
     </modules>
     <properties>
-        <revision.major>2</revision.major>
-        <revision.minor>1</revision.minor>
+        <revision.major>3</revision.major>
+        <revision.minor>0</revision.minor>
         <revision.patch>0</revision.patch>
         <revision>${revision.major}.${revision.minor}.${revision.patch}-SNAPSHOT</revision>
-        <model.version>2.1.0-SNAPSHOT</model.version>
+        <model.version>3.0.0-SNAPSHOT</model.version>
 
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <plugin.central-publishing-maven-plugin.version>0.10.0</plugin.central-publishing-maven-plugin.version>
@@ -116,15 +118,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${plugin.compiler.version}</version>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,14 +63,13 @@
         <guava.version>33.6.0-jre</guava.version>
         <guice.version>5.0.1</guice.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <jackson.version>2.21.2</jackson.version>
-        <jackson-annotations.version>2.21</jackson-annotations.version>
+        <jackson-bom.version>3.1.3</jackson-bom.version>
         <javax-validation.version>2.0.1.Final</javax-validation.version>
         <jaxb.version>2.3.1</jaxb.version>
         <jaxb-rich-contract.version>2.1.0</jaxb-rich-contract.version>
         <jena.version>4.1.0</jena.version>
         <jsonassert.version>1.5.3</jsonassert.version>
-        <json-schema-validator.version>2.0.0</json-schema-validator.version>
+        <json-schema-validator.version>3.0.2</json-schema-validator.version>
         <junit.version>4.13.2</junit.version>
         <junit-params.version>1.1.1</junit-params.version>
         <moxy.version>2.7.8</moxy.version>
@@ -123,8 +122,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${plugin.compiler.version}</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -265,6 +264,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
@@ -334,19 +340,19 @@
                 <version>${commons-io.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
+                <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-bom.version}</version>
             </dependency>
              <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
+                <groupId>tools.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-bom.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson-annotations.version}</version>
+                <version>2.21</version>
             </dependency>
             <dependency>
                 <groupId>io.github.classgraph</groupId>
@@ -374,9 +380,9 @@
                 <version>${vaadin.version}</version>
             </dependency>
           <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <groupId>tools.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-bom.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.xmlunit</groupId>


### PR DESCRIPTION
Closes #473. Also unblocks #479.

Upgrades all Jackson dependencies from 2.21.x to Jackson 3.1.3 (first LTS
release in the 3.x line) and upgrades json-schema-validator from 2.0.0 to
3.0.2 simultaneously, since that library already uses Jackson 3 internally
and was causing a compilation failure in JsonSchemaValidator.java when
bumped independently.

Breaking changes (build/runtime)
---------------------------------
- Java 17 is now required (Jackson 3 baseline).
- Maven group IDs changed: com.fasterxml.jackson.core/dataformat ->
  tools.jackson.core/dataformat. Projects that depend on aas4j and override
  Jackson versions must update their POMs accordingly.
  Exception: jackson-annotations keeps com.fasterxml.jackson.core.

Changes
-------
- Root pom.xml: add tools.jackson:jackson-bom:3.1.3, raise Java
  source/target to 17, bump json-schema-validator to 3.0.2.
- All Jackson package imports renamed: com.fasterxml.jackson.* ->
  tools.jackson.* (except com.fasterxml.jackson.annotation.*).
- JsonSerializer / JsonDeserializer -> ValueSerializer / ValueDeserializer;
  SerializerProvider -> SerializationContext.
- Annotation introspector overrides updated for the new MapperConfig<?>
  parameter; findTypeResolver -> findTypeResolverBuilder using
  StdTypeResolverBuilder(JsonTypeInfo.Value).
- serializationInclusion() -> changeDefaultPropertyInclusion(); mixin
  registration moved from post-build() to the builder (immutable mapper).
- parser.getCodec() / ObjectCodec removed; replaced with
  ctxt.readTreeAsValue() / ctxt.readTree().
- FromXmlParser.Feature -> XmlReadFeature;
  ToXmlGenerator.Feature -> XmlWriteFeature.
- JsonGenerator method renames: writeFieldName -> writeName,
  writeStringField -> writeStringProperty,
  writeObjectField -> writePOJOProperty,
  writeArrayFieldStart -> writeArrayPropertyStart.
- TextNode -> StringNode; fieldNames() -> propertyNames().iterator().
- CustomJsonNodeDeserializer interface signature updated from
  (JsonNode, JsonParser) to (JsonNode, DeserializationContext).
- All 5338 existing tests pass unchanged.