### PR TITLE
fix(#468): Add SubmodelElementList constraint validation via EnvironmentConstraintValidator

### DIFF
--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/ConstraintValidatorRegistry.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/ConstraintValidatorRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
+
+import java.util.List;
+
+/**
+ * Central registry of all {@link EnvironmentConstraintValidator} instances applied during schema
+ * validation.
+ *
+ * <p>To add a new constraint validator, append an instance to the list below. Neither the schema
+ * validators nor any other caller needs to change.
+ */
+public final class ConstraintValidatorRegistry {
+
+  private static final List<EnvironmentConstraintValidator> VALIDATORS =
+      List.of(new SubmodelElementListConstraintValidator());
+
+  private ConstraintValidatorRegistry() {}
+
+  /**
+   * Returns the immutable list of all registered constraint validators.
+   *
+   * @return unmodifiable list of validators
+   */
+  public static List<EnvironmentConstraintValidator> getValidators() {
+    return VALIDATORS;
+  }
+}

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/EnvironmentConstraintValidator.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/EnvironmentConstraintValidator.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
+
+import java.util.Set;
+import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
+
+/**
+ * Contract for validators that check AAS Metamodel Part 1 constraints on a deserialized {@link
+ * Environment}.
+ */
+public interface EnvironmentConstraintValidator {
+
+  /**
+   * Validates AAS metamodel constraints on the given environment.
+   *
+   * @param environment the already-deserialized environment to validate
+   * @return set of violation messages; empty when the environment is valid
+   */
+  Set<String> validate(Environment environment);
+}

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/SubmodelElementListConstraintValidator.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/SubmodelElementListConstraintValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util.SubmodelElementListValidator;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.visitor.AssetAdministrationShellElementWalkerVisitor;
+import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
+
+/**
+ * Validates AAS Metamodel Part 1 structural constraints on {@link SubmodelElementList} instances.
+ *
+ * <p>Checks that:
+ *
+ * <ul>
+ *   <li>every child element matches the type declared in {@code typeValueListElement}
+ *   <li>every {@code Property} and {@code Range} child has a {@code valueType} matching {@code
+ *       valueTypeListElement} (when set)
+ * </ul>
+ *
+ * <p>Use {@link #validate(SubmodelElementList)} for a single list, or {@link
+ * #validate(Environment)} to check all lists in an entire environment at any nesting depth.
+ */
+public class SubmodelElementListConstraintValidator implements EnvironmentConstraintValidator {
+
+  /**
+   * Validates constraints on a single {@link SubmodelElementList}.
+   *
+   * @param list the list to validate
+   * @return set of violation messages; empty when the list is valid
+   */
+  public Set<String> validate(SubmodelElementList list) {
+    Set<String> errors = new HashSet<>();
+    try {
+      SubmodelElementListValidator.validateTypeValueListElement(list);
+    } catch (IOException e) {
+      errors.add(e.getMessage());
+    }
+    try {
+      SubmodelElementListValidator.validateValueTypeListElement(list);
+    } catch (IOException e) {
+      errors.add(e.getMessage());
+    }
+    return errors;
+  }
+
+  /**
+   * Validates constraints on every {@link SubmodelElementList} found anywhere in the given {@link
+   * Environment}, at any nesting depth.
+   *
+   * @param environment the environment to validate
+   * @return set of violation messages; empty when all lists are valid
+   */
+  @Override
+  public Set<String> validate(Environment environment) {
+    Set<String> errors = new HashSet<>();
+    new AssetAdministrationShellElementWalkerVisitor() {
+      @Override
+      public void visit(SubmodelElementList list) {
+        errors.addAll(SubmodelElementListConstraintValidator.this.validate(list));
+        AssetAdministrationShellElementWalkerVisitor.super.visit(list);
+      }
+    }.visit(environment);
+    return errors;
+  }
+}

--- a/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/util/SubmodelElementListValidator.java
+++ b/dataformat-core/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/util/SubmodelElementListValidator.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
+import org.eclipse.digitaltwin.aas4j.v3.model.AnnotatedRelationshipElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.BasicEventElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.Blob;
+import org.eclipse.digitaltwin.aas4j.v3.model.Capability;
+import org.eclipse.digitaltwin.aas4j.v3.model.DataElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
+import org.eclipse.digitaltwin.aas4j.v3.model.Entity;
+import org.eclipse.digitaltwin.aas4j.v3.model.EventElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.File;
+import org.eclipse.digitaltwin.aas4j.v3.model.MultiLanguageProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.Operation;
+import org.eclipse.digitaltwin.aas4j.v3.model.Property;
+import org.eclipse.digitaltwin.aas4j.v3.model.Range;
+import org.eclipse.digitaltwin.aas4j.v3.model.ReferenceElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.RelationshipElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementCollection;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
+
+/** Validates AAS Metamodel Part 1 structural constraints on {@link SubmodelElementList}. */
+public class SubmodelElementListValidator {
+
+  private static final Map<AasSubmodelElements, Class<? extends SubmodelElement>> TYPE_MAP =
+      new EnumMap<>(AasSubmodelElements.class);
+
+  static {
+    TYPE_MAP.put(
+        AasSubmodelElements.ANNOTATED_RELATIONSHIP_ELEMENT, AnnotatedRelationshipElement.class);
+    TYPE_MAP.put(AasSubmodelElements.BASIC_EVENT_ELEMENT, BasicEventElement.class);
+    TYPE_MAP.put(AasSubmodelElements.BLOB, Blob.class);
+    TYPE_MAP.put(AasSubmodelElements.CAPABILITY, Capability.class);
+    TYPE_MAP.put(AasSubmodelElements.DATA_ELEMENT, DataElement.class);
+    TYPE_MAP.put(AasSubmodelElements.ENTITY, Entity.class);
+    TYPE_MAP.put(AasSubmodelElements.EVENT_ELEMENT, EventElement.class);
+    TYPE_MAP.put(AasSubmodelElements.FILE, File.class);
+    TYPE_MAP.put(AasSubmodelElements.MULTI_LANGUAGE_PROPERTY, MultiLanguageProperty.class);
+    TYPE_MAP.put(AasSubmodelElements.OPERATION, Operation.class);
+    TYPE_MAP.put(AasSubmodelElements.PROPERTY, Property.class);
+    TYPE_MAP.put(AasSubmodelElements.RANGE, Range.class);
+    TYPE_MAP.put(AasSubmodelElements.REFERENCE_ELEMENT, ReferenceElement.class);
+    TYPE_MAP.put(AasSubmodelElements.RELATIONSHIP_ELEMENT, RelationshipElement.class);
+    TYPE_MAP.put(AasSubmodelElements.SUBMODEL_ELEMENT, SubmodelElement.class);
+    TYPE_MAP.put(AasSubmodelElements.SUBMODEL_ELEMENT_COLLECTION, SubmodelElementCollection.class);
+    TYPE_MAP.put(AasSubmodelElements.SUBMODEL_ELEMENT_LIST, SubmodelElementList.class);
+  }
+
+  private SubmodelElementListValidator() {}
+
+  /**
+   * Validates that every child of {@code list} is an instance of the type declared by {@code
+   * typeValueListElement}. No-op when {@code typeValueListElement} is null or when the declared
+   * type is not in the known type map (custom/unknown types are skipped).
+   *
+   * @throws IOException when a child's type does not match the declared type
+   */
+  public static void validateTypeValueListElement(SubmodelElementList list) throws IOException {
+    AasSubmodelElements declaredType = list.getTypeValueListElement();
+    if (declaredType == null) {
+      return;
+    }
+    Class<? extends SubmodelElement> expectedClass = TYPE_MAP.get(declaredType);
+    if (expectedClass == null) {
+      return;
+    }
+    List<SubmodelElement> children = list.getValue();
+    if (children == null || children.isEmpty()) {
+      return;
+    }
+    for (SubmodelElement child : children) {
+      if (child == null) {
+        continue;
+      }
+      if (!expectedClass.isInstance(child)) {
+        throw new IOException(
+            String.format(
+                "SubmodelElementList constraint violation: typeValueListElement is '%s' but child"
+                    + " element is of type '%s'",
+                declaredType, child.getClass().getSimpleName()));
+      }
+    }
+  }
+
+  /**
+   * Validates that every {@link Property} and {@link Range} child of {@code list} has a {@code
+   * valueType} matching {@code valueTypeListElement}. No-op when {@code valueTypeListElement} is
+   * null.
+   *
+   * @throws IOException when a child's valueType does not match the declared valueTypeListElement
+   */
+  public static void validateValueTypeListElement(SubmodelElementList list) throws IOException {
+    DataTypeDefXsd declaredValueType = list.getValueTypeListElement();
+    if (declaredValueType == null) {
+      return;
+    }
+    List<SubmodelElement> children = list.getValue();
+    if (children == null || children.isEmpty()) {
+      return;
+    }
+    for (SubmodelElement child : children) {
+      if (child == null) {
+        continue;
+      }
+      if (child instanceof Property) {
+        DataTypeDefXsd actual = ((Property) child).getValueType();
+        if (actual != null && actual != declaredValueType) {
+          throw new IOException(
+              String.format(
+                  "SubmodelElementList constraint violation: valueTypeListElement is '%s' but"
+                      + " Property child has valueType '%s'",
+                  declaredValueType, actual));
+        }
+      } else if (child instanceof Range) {
+        DataTypeDefXsd actual = ((Range) child).getValueType();
+        if (actual != null && actual != declaredValueType) {
+          throw new IOException(
+              String.format(
+                  "SubmodelElementList constraint violation: valueTypeListElement is '%s' but"
+                      + " Range child has valueType '%s'",
+                  declaredValueType, actual));
+        }
+      }
+    }
+  }
+
+  /**
+   * Convenience method that runs both {@link #validateTypeValueListElement} and {@link
+   * #validateValueTypeListElement}.
+   *
+   * @throws IOException when any constraint is violated
+   */
+  public static void validate(SubmodelElementList list) throws IOException {
+    validateTypeValueListElement(list);
+    validateValueTypeListElement(list);
+  }
+}

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/ConstraintValidatorRegistryTest.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/ConstraintValidatorRegistryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import org.junit.Test;
+
+public class ConstraintValidatorRegistryTest {
+
+  @Test
+  public void registryIsNotEmpty() {
+    assertFalse(ConstraintValidatorRegistry.getValidators().isEmpty());
+  }
+
+  @Test
+  public void registryContainsSubmodelElementListConstraintValidator() {
+    List<EnvironmentConstraintValidator> validators = ConstraintValidatorRegistry.getValidators();
+    assertTrue(
+        validators.stream().anyMatch(v -> v instanceof SubmodelElementListConstraintValidator));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void registryListIsUnmodifiable() {
+    ConstraintValidatorRegistry.getValidators().add(env -> java.util.Collections.emptySet());
+  }
+
+  @Test
+  public void getValidators_returnsSameListInstance() {
+    assertSame(
+        ConstraintValidatorRegistry.getValidators(), ConstraintValidatorRegistry.getValidators());
+  }
+}

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/SubmodelElementListConstraintValidatorTest.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/SubmodelElementListConstraintValidatorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
+import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultBlob;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultRange;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementList;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SubmodelElementListConstraintValidatorTest {
+
+  private SubmodelElementListConstraintValidator validator;
+
+  @Before
+  public void setup() {
+    validator = new SubmodelElementListConstraintValidator();
+  }
+
+  @Test
+  public void validList_returnsEmptySet() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.STRING).build(),
+            new DefaultProperty.Builder().idShort("p2").valueType(DataTypeDefXsd.STRING).build()));
+
+    assertTrue(validator.validate(list).isEmpty());
+  }
+
+  @Test
+  public void typeMismatch_returnsViolation() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.STRING).build(),
+            new DefaultBlob.Builder().idShort("b1").build()));
+
+    Set<String> errors = validator.validate(list);
+    assertFalse(errors.isEmpty());
+    assertTrue(errors.iterator().next().contains("typeValueListElement"));
+  }
+
+  @Test
+  public void valueTypeMismatch_returnsViolation() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValueTypeListElement(DataTypeDefXsd.STRING);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.INT).build()));
+
+    Set<String> errors = validator.validate(list);
+    assertFalse(errors.isEmpty());
+    assertTrue(errors.iterator().next().contains("valueTypeListElement"));
+  }
+
+  @Test
+  public void rangeMismatch_returnsViolation() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.RANGE);
+    list.setValueTypeListElement(DataTypeDefXsd.STRING);
+    list.setValue(
+        Arrays.asList(
+            new DefaultRange.Builder().idShort("r1").valueType(DataTypeDefXsd.INT).build()));
+
+    Set<String> errors = validator.validate(list);
+    assertFalse(errors.isEmpty());
+  }
+
+  @Test
+  public void emptyList_returnsEmptySet() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(Collections.emptyList());
+
+    assertTrue(validator.validate(list).isEmpty());
+  }
+
+  @Test
+  public void noDeclaredType_returnsEmptySet() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setValue(Arrays.asList(new DefaultBlob.Builder().idShort("b1").build()));
+
+    assertTrue(validator.validate(list).isEmpty());
+  }
+
+  @Test
+  public void bothViolations_returnsTwoErrors() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValueTypeListElement(DataTypeDefXsd.STRING);
+    // Blob violates typeValueListElement; property violates valueTypeListElement
+    list.setValue(
+        Arrays.asList(
+            new DefaultBlob.Builder().idShort("b1").build(),
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.INT).build()));
+
+    assertEquals(2, validator.validate(list).size());
+  }
+}

--- a/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/util/SubmodelElementListValidatorTest.java
+++ b/dataformat-core/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/core/internal/util/SubmodelElementListValidatorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.core.internal.util;
+
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.eclipse.digitaltwin.aas4j.v3.model.AasSubmodelElements;
+import org.eclipse.digitaltwin.aas4j.v3.model.DataTypeDefXsd;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultBlob;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultRange;
+import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelElementList;
+import org.junit.Test;
+
+public class SubmodelElementListValidatorTest {
+
+  // --- validateTypeValueListElement ---
+
+  @Test
+  public void typeValue_allMatch_passes() throws IOException {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.STRING).build(),
+            new DefaultProperty.Builder().idShort("p2").valueType(DataTypeDefXsd.INT).build()));
+
+    SubmodelElementListValidator.validateTypeValueListElement(list);
+  }
+
+  @Test
+  public void typeValue_mismatch_throws() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.STRING).build(),
+            new DefaultBlob.Builder().idShort("b1").build()));
+
+    assertThrows(
+        IOException.class, () -> SubmodelElementListValidator.validateTypeValueListElement(list));
+  }
+
+  @Test
+  public void typeValue_emptyList_passes() throws IOException {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(Collections.emptyList());
+
+    SubmodelElementListValidator.validateTypeValueListElement(list);
+  }
+
+  @Test
+  public void typeValue_nullList_passes() throws IOException {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValue(null);
+
+    SubmodelElementListValidator.validateTypeValueListElement(list);
+  }
+
+  @Test
+  public void typeValue_nullDeclaredType_passes() throws IOException {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(null);
+    list.setValue(Arrays.asList(new DefaultBlob.Builder().idShort("b1").build()));
+
+    SubmodelElementListValidator.validateTypeValueListElement(list);
+  }
+
+  // --- validateValueTypeListElement ---
+
+  @Test
+  public void valueType_allMatch_passes() throws IOException {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValueTypeListElement(DataTypeDefXsd.STRING);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.STRING).build(),
+            new DefaultProperty.Builder().idShort("p2").valueType(DataTypeDefXsd.STRING).build()));
+
+    SubmodelElementListValidator.validateValueTypeListElement(list);
+  }
+
+  @Test
+  public void valueType_mismatch_throws() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValueTypeListElement(DataTypeDefXsd.STRING);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.INT).build()));
+
+    assertThrows(
+        IOException.class, () -> SubmodelElementListValidator.validateValueTypeListElement(list));
+  }
+
+  @Test
+  public void valueType_rangeMismatch_throws() {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.RANGE);
+    list.setValueTypeListElement(DataTypeDefXsd.STRING);
+    list.setValue(
+        Arrays.asList(
+            new DefaultRange.Builder().idShort("r1").valueType(DataTypeDefXsd.INT).build()));
+
+    assertThrows(
+        IOException.class, () -> SubmodelElementListValidator.validateValueTypeListElement(list));
+  }
+
+  @Test
+  public void valueType_notSet_passes() throws IOException {
+    DefaultSubmodelElementList list = new DefaultSubmodelElementList();
+    list.setTypeValueListElement(AasSubmodelElements.PROPERTY);
+    list.setValueTypeListElement(null);
+    list.setValue(
+        Arrays.asList(
+            new DefaultProperty.Builder().idShort("p1").valueType(DataTypeDefXsd.INT).build()));
+
+    SubmodelElementListValidator.validateValueTypeListElement(list);
+  }
+}

--- a/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSchemaValidator.java
+++ b/dataformat-json/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonSchemaValidator.java
@@ -29,6 +29,9 @@ import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.ConstraintValidatorRegistry;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.EnvironmentConstraintValidator;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SchemaValidator;
 
 /**
@@ -39,11 +42,13 @@ public class JsonSchemaValidator implements SchemaValidator {
 
   private static final String SCHEMA = "/aas.json";
   private final ObjectMapper mapper = new ObjectMapper();
+  private final JsonDeserializer deserializer = new JsonDeserializer();
 
   public JsonSchemaValidator() {}
 
   /**
-   * validates against default schema
+   * Validates against the default schema and checks AAS metamodel constraints (e.g. {@code
+   * typeValueListElement} and {@code valueTypeListElement} on {@code SubmodelElementList}).
    *
    * @param serialized AssetAdministrationShellEnvironment, serialized as json string
    * @return Set of messages to display validation results
@@ -51,8 +56,26 @@ public class JsonSchemaValidator implements SchemaValidator {
   @Override
   public Set<String> validateSchema(String serialized) {
     try {
-      return new HashSet<>(validateSchema(serialized, loadDefaultSchema()));
+      Set<String> errors = new HashSet<>(validateSchema(serialized, loadDefaultSchema()));
+      if (errors.isEmpty()) {
+        errors.addAll(validateConstraints(serialized));
+      }
+      return errors;
     } catch (IOException | URISyntaxException e) {
+      return Set.of(e.getMessage());
+    }
+  }
+
+  private Set<String> validateConstraints(String serialized) {
+    try {
+      org.eclipse.digitaltwin.aas4j.v3.model.Environment env =
+          deserializer.read(serialized, org.eclipse.digitaltwin.aas4j.v3.model.Environment.class);
+      Set<String> errors = new HashSet<>();
+      for (EnvironmentConstraintValidator v : ConstraintValidatorRegistry.getValidators()) {
+        errors.addAll(v.validate(env));
+      }
+      return errors;
+    } catch (DeserializationException e) {
       return Set.of(e.getMessage());
     }
   }

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonValidationTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/JsonValidationTest.java
@@ -109,6 +109,46 @@ public class JsonValidationTest {
     assertFalse(validate(file).isEmpty());
   }
 
+  @Test
+  public void validateSubmodelElementList_validTypeConstraint_noErrors() {
+    String json =
+        "{"
+            + "\"submodels\":[{"
+            + "  \"modelType\":\"Submodel\","
+            + "  \"id\":\"sm1\",\"idShort\":\"sm1\","
+            + "  \"submodelElements\":[{"
+            + "    \"modelType\":\"SubmodelElementList\","
+            + "    \"idShort\":\"list1\","
+            + "    \"typeValueListElement\":\"Property\","
+            + "    \"value\":["
+            + "      {\"modelType\":\"Property\",\"idShort\":\"p1\",\"valueType\":\"xs:string\"},"
+            + "      {\"modelType\":\"Property\",\"idShort\":\"p2\",\"valueType\":\"xs:string\"}"
+            + "    ]"
+            + "  }]"
+            + "}]}";
+    assertTrue(validator.validateSchema(json).isEmpty());
+  }
+
+  @Test
+  public void validateSubmodelElementList_typeConstraintViolation_reportsError() {
+    String json =
+        "{"
+            + "\"submodels\":[{"
+            + "  \"modelType\":\"Submodel\","
+            + "  \"id\":\"sm1\",\"idShort\":\"sm1\","
+            + "  \"submodelElements\":[{"
+            + "    \"modelType\":\"SubmodelElementList\","
+            + "    \"idShort\":\"list1\","
+            + "    \"typeValueListElement\":\"Property\","
+            + "    \"value\":["
+            + "      {\"modelType\":\"Property\",\"idShort\":\"p1\",\"valueType\":\"xs:string\"},"
+            + "      {\"modelType\":\"Blob\",\"idShort\":\"b1\"}"
+            + "    ]"
+            + "  }]"
+            + "}]}";
+    assertFalse(validator.validateSchema(json).isEmpty());
+  }
+
   private Set<String> validate(String file) throws IOException {
     String json = new String(Files.readAllBytes(Paths.get(file)));
     Set<String> result = validator.validateSchema(json);

--- a/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/SubmodelElementListValidationTest.java
+++ b/dataformat-json/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/json/SubmodelElementListValidationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.json;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SubmodelElementListConstraintValidator;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SubmodelElementListValidationTest {
+
+  private static JsonDeserializer deserializer;
+  private static SubmodelElementListConstraintValidator validator;
+
+  @BeforeClass
+  public static void setup() {
+    deserializer = new JsonDeserializer();
+    validator = new SubmodelElementListConstraintValidator();
+  }
+
+  @Test
+  public void validList_passesDeserialization_andValidation() throws Exception {
+    String json =
+        "{"
+            + "\"modelType\":\"SubmodelElementList\","
+            + "\"idShort\":\"testList\","
+            + "\"typeValueListElement\":\"Property\","
+            + "\"value\":["
+            + "  {\"modelType\":\"Property\",\"idShort\":\"p1\",\"valueType\":\"xs:string\"},"
+            + "  {\"modelType\":\"Property\",\"idShort\":\"p2\",\"valueType\":\"xs:string\"}"
+            + "]"
+            + "}";
+    SubmodelElementList result = deserializer.read(json, SubmodelElementList.class);
+    assertTrue(validator.validate(result).isEmpty());
+  }
+
+  @Test
+  public void typeMismatch_deserializationSucceeds_validationFails() throws Exception {
+    String json =
+        "{"
+            + "\"modelType\":\"SubmodelElementList\","
+            + "\"idShort\":\"testList\","
+            + "\"typeValueListElement\":\"Property\","
+            + "\"value\":["
+            + "  {\"modelType\":\"Property\",\"idShort\":\"p1\",\"valueType\":\"xs:string\"},"
+            + "  {\"modelType\":\"Blob\",\"idShort\":\"b1\"}"
+            + "]"
+            + "}";
+    SubmodelElementList result = deserializer.read(json, SubmodelElementList.class);
+    assertFalse(validator.validate(result).isEmpty());
+  }
+
+  @Test
+  public void valueTypeMismatch_deserializationSucceeds_validationFails() throws Exception {
+    String json =
+        "{"
+            + "\"modelType\":\"SubmodelElementList\","
+            + "\"idShort\":\"testList\","
+            + "\"typeValueListElement\":\"Property\","
+            + "\"valueTypeListElement\":\"xs:string\","
+            + "\"value\":["
+            + "  {\"modelType\":\"Property\",\"idShort\":\"p1\",\"valueType\":\"xs:int\"}"
+            + "]"
+            + "}";
+    SubmodelElementList result = deserializer.read(json, SubmodelElementList.class);
+    assertFalse(validator.validate(result).isEmpty());
+  }
+
+  @Test
+  public void listNestedInSubmodelElementList_innerViolationDetectedByValidator() throws Exception {
+    String json =
+        "{"
+            + "\"modelType\":\"SubmodelElementList\","
+            + "\"idShort\":\"outer\","
+            + "\"typeValueListElement\":\"SubmodelElementList\","
+            + "\"value\":["
+            + "  {"
+            + "    \"modelType\":\"SubmodelElementList\","
+            + "    \"idShort\":\"inner\","
+            + "    \"typeValueListElement\":\"Property\","
+            + "    \"value\":["
+            + "      {\"modelType\":\"Blob\",\"idShort\":\"b1\"}"
+            + "    ]"
+            + "  }"
+            + "]"
+            + "}";
+    SubmodelElementList outer = deserializer.read(json, SubmodelElementList.class);
+    // outer is valid (contains SubmodelElementLists), but inner list is not
+    assertTrue(validator.validate(outer).isEmpty());
+    SubmodelElementList inner = (SubmodelElementList) outer.getValue().get(0);
+    assertFalse(validator.validate(inner).isEmpty());
+  }
+}

--- a/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSchemaValidator.java
+++ b/dataformat-xml/src/main/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlSchemaValidator.java
@@ -23,12 +23,16 @@ import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.ConstraintValidatorRegistry;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.DeserializationException;
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.EnvironmentConstraintValidator;
 import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SchemaValidator;
 import org.xml.sax.SAXException;
 
 public class XmlSchemaValidator implements SchemaValidator {
   private static final String SCHEMA = "/AAS.xsd";
   protected Schema schema;
+  private final XmlDeserializer deserializer = new XmlDeserializer();
 
   public XmlSchemaValidator() throws SAXException {
     loadSchemaFromResource();
@@ -39,6 +43,13 @@ public class XmlSchemaValidator implements SchemaValidator {
     schema = factory.newSchema(getClass().getResource(SCHEMA));
   }
 
+  /**
+   * Validates against the default schema and checks AAS metamodel constraints (e.g. {@code
+   * typeValueListElement} and {@code valueTypeListElement} on {@code SubmodelElementList}).
+   *
+   * @param serializedAASEnvironment A string-serialized AASEnvironment.
+   * @return Set of validation errors. If validation succeeds, the Set is empty.
+   */
   @Override
   public Set<String> validateSchema(String serializedAASEnvironment) {
     Set<String> errorMessages = new HashSet<>();
@@ -49,7 +60,21 @@ public class XmlSchemaValidator implements SchemaValidator {
       errorMessages.add(se.getMessage());
       return errorMessages;
     }
+    errorMessages.addAll(validateConstraints(serializedAASEnvironment));
     return errorMessages;
+  }
+
+  private Set<String> validateConstraints(String serialized) {
+    try {
+      org.eclipse.digitaltwin.aas4j.v3.model.Environment env = deserializer.read(serialized);
+      Set<String> errors = new HashSet<>();
+      for (EnvironmentConstraintValidator v : ConstraintValidatorRegistry.getValidators()) {
+        errors.addAll(v.validate(env));
+      }
+      return errors;
+    } catch (DeserializationException e) {
+      return Set.of(e.getMessage());
+    }
   }
 
   private static String stripBom(String value) {

--- a/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/SubmodelElementListValidationTest.java
+++ b/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/SubmodelElementListValidationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e. V.
+ * Copyright (c) 2023, SAP SE or an SAP affiliate company
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.digitaltwin.aas4j.v3.dataformat.core.SubmodelElementListConstraintValidator;
+import org.eclipse.digitaltwin.aas4j.v3.model.Environment;
+import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElementList;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SubmodelElementListValidationTest {
+
+  private static XmlDeserializer deserializer;
+  private static SubmodelElementListConstraintValidator validator;
+
+  @BeforeClass
+  public static void setup() {
+    deserializer = new XmlDeserializer();
+    validator = new SubmodelElementListConstraintValidator();
+  }
+
+  private static String wrap(String submodelElementListXml) {
+    return "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+        + "<environment xmlns=\"https://admin-shell.io/aas/3/1\">"
+        + "<submodels><submodel><id>test</id><idShort>test</idShort>"
+        + "<submodelElements>"
+        + submodelElementListXml
+        + "</submodelElements></submodel></submodels>"
+        + "</environment>";
+  }
+
+  private SubmodelElementList firstList(String xml) throws Exception {
+    Environment env = deserializer.read(xml);
+    return (SubmodelElementList) env.getSubmodels().get(0).getSubmodelElements().get(0);
+  }
+
+  @Test
+  public void validList_passesDeserialization_andValidation() throws Exception {
+    String xml =
+        wrap(
+            "<submodelElementList>"
+                + "<idShort>testList</idShort>"
+                + "<typeValueListElement>Property</typeValueListElement>"
+                + "<value>"
+                + "<property><idShort>p1</idShort><valueType>xs:string</valueType></property>"
+                + "<property><idShort>p2</idShort><valueType>xs:string</valueType></property>"
+                + "</value>"
+                + "</submodelElementList>");
+    assertTrue(validator.validate(firstList(xml)).isEmpty());
+  }
+
+  @Test
+  public void typeMismatch_deserializationSucceeds_validationFails() throws Exception {
+    String xml =
+        wrap(
+            "<submodelElementList>"
+                + "<idShort>testList</idShort>"
+                + "<typeValueListElement>Property</typeValueListElement>"
+                + "<value>"
+                + "<property><idShort>p1</idShort><valueType>xs:string</valueType></property>"
+                + "<blob><idShort>b1</idShort></blob>"
+                + "</value>"
+                + "</submodelElementList>");
+    assertFalse(validator.validate(firstList(xml)).isEmpty());
+  }
+
+  @Test
+  public void valueTypeMismatch_deserializationSucceeds_validationFails() throws Exception {
+    String xml =
+        wrap(
+            "<submodelElementList>"
+                + "<idShort>testList</idShort>"
+                + "<typeValueListElement>Property</typeValueListElement>"
+                + "<valueTypeListElement>xs:string</valueTypeListElement>"
+                + "<value>"
+                + "<property><idShort>p1</idShort><valueType>xs:int</valueType></property>"
+                + "</value>"
+                + "</submodelElementList>");
+    assertFalse(validator.validate(firstList(xml)).isEmpty());
+  }
+
+  @Test
+  public void listNestedInSubmodelElementList_innerViolationDetectedByValidator() throws Exception {
+    String xml =
+        wrap(
+            "<submodelElementList>"
+                + "<idShort>outer</idShort>"
+                + "<typeValueListElement>SubmodelElementList</typeValueListElement>"
+                + "<value>"
+                + "<submodelElementList>"
+                + "<idShort>inner</idShort>"
+                + "<typeValueListElement>Property</typeValueListElement>"
+                + "<value>"
+                + "<blob><idShort>b1</idShort></blob>"
+                + "</value>"
+                + "</submodelElementList>"
+                + "</value>"
+                + "</submodelElementList>");
+    SubmodelElementList outer = firstList(xml);
+    // outer is valid (contains SubmodelElementLists)
+    assertTrue(validator.validate(outer).isEmpty());
+    SubmodelElementList inner = (SubmodelElementList) outer.getValue().get(0);
+    assertFalse(validator.validate(inner).isEmpty());
+  }
+}

--- a/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlValidationTest.java
+++ b/dataformat-xml/src/test/java/org/eclipse/digitaltwin/aas4j/v3/dataformat/xml/XmlValidationTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.digitaltwin.aas4j.v3.dataformat.xml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -74,6 +75,52 @@ public class XmlValidationTest {
     Set<String> errors = validateXmlFile(file);
     logErrors(file, errors);
     assertEquals(1, errors.size());
+  }
+
+  @Test
+  public void validateSubmodelElementList_validTypeConstraint_noErrors() {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+            + "<environment xmlns=\"https://admin-shell.io/aas/3/1\">"
+            + "<submodels><submodel>"
+            + "<idShort>sm1</idShort><id>sm1</id>"
+            + "<submodelElements>"
+            + "<submodelElementList>"
+            + "<idShort>list1</idShort>"
+            + "<typeValueListElement>Property</typeValueListElement>"
+            + "<value>"
+            + "<property><idShort>p1</idShort><valueType>xs:string</valueType></property>"
+            + "<property><idShort>p2</idShort><valueType>xs:string</valueType></property>"
+            + "</value>"
+            + "</submodelElementList>"
+            + "</submodelElements></submodel></submodels>"
+            + "</environment>";
+    Set<String> errors = validator.validateSchema(xml);
+    logErrors("valid SubmodelElementList", errors);
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  public void validateSubmodelElementList_typeConstraintViolation_reportsError() {
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+            + "<environment xmlns=\"https://admin-shell.io/aas/3/1\">"
+            + "<submodels><submodel>"
+            + "<idShort>sm1</idShort><id>sm1</id>"
+            + "<submodelElements>"
+            + "<submodelElementList>"
+            + "<idShort>list1</idShort>"
+            + "<typeValueListElement>Property</typeValueListElement>"
+            + "<value>"
+            + "<property><idShort>p1</idShort><valueType>xs:string</valueType></property>"
+            + "<blob><idShort>b1</idShort></blob>"
+            + "</value>"
+            + "</submodelElementList>"
+            + "</submodelElements></submodel></submodels>"
+            + "</environment>";
+    Set<String> errors = validator.validateSchema(xml);
+    logErrors("invalid SubmodelElementList", errors);
+    assertFalse(errors.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #468.

`SubmodelElementList` declares `typeValueListElement` (required child element type) and `valueTypeListElement` (required XSD data type for `Property`/`Range` children), but nothing in AAS4J enforced these AAS Metamodel Part 1 constraints. Invalid object graphs were silently accepted.

- Introduces `EnvironmentConstraintValidator` interface (`dataformat-core`) — a common contract for model-level constraint validators, mirroring the existing `SchemaValidator` pattern.
- Introduces `ConstraintValidatorRegistry` — a single place listing all registered validators; adding a future validator requires only one line there.
- Adds `SubmodelElementListConstraintValidator` implementing the interface, which validates `typeValueListElement` and `valueTypeListElement` on every `SubmodelElementList` at any nesting depth (via `AssetAdministrationShellElementWalkerVisitor`).
- Wires the registry into `JsonSchemaValidator` and `XmlSchemaValidator` so constraint checks run automatically after schema validation passes — no API changes for existing callers.
- Validation is **decoupled from deserialization**: `SubmodelElementListConstraintValidator` can also be called standalone on a single list or a full environment.

## Test plan

- [ ] `ConstraintValidatorRegistryTest` — registry is non-empty, contains expected type, is unmodifiable, returns same instance
- [ ] `SubmodelElementListConstraintValidatorTest` — valid list passes, type mismatch reported, value-type mismatch reported, empty list passes, both violations return two errors
- [ ] `SubmodelElementListValidatorTest` (internal utility) — all scenarios
- [ ] `JsonValidationTest` — valid list produces no errors, type-mismatch list produces errors via `JsonSchemaValidator.validateSchema()`
- [ ] `XmlValidationTest` — same two cases for XML
- [ ] `SubmodelElementListValidationTest` (JSON + XML) — deserialization succeeds for invalid lists; calling the validator directly detects the violation; nested lists detected correctly
- [ ] Full suite: `mvn test -pl dataformat-json,dataformat-xml,dataformat-aasx` — all pass